### PR TITLE
Fix issue that ClassID does not allocate classid properly with quickjs-ng

### DIFF
--- a/impl/quickjs/jsb_quickjs_isolate.h
+++ b/impl/quickjs/jsb_quickjs_isolate.h
@@ -66,7 +66,7 @@ namespace jsb::impl
     struct ClassID
     {
 #if JSB_PREFER_QUICKJS_NG
-        jsb_force_inline void init(JSRuntime* rt) { JS_NewClassID(rt, &id_); }
+        jsb_force_inline void init(JSRuntime* rt) { id_ = 0; JS_NewClassID(rt, &id_); }
         explicit operator JSClassID() const { return id_; }
 
     private:


### PR DESCRIPTION
JS_NewClassID of quickjs-ng expect that provided reference classid contains 0 otherwise do nothing. Perhaps consider that classid is already valid. This patch fixit by seting classid to 0 before calling JS_NewClassID.

Note: the documentation of JS_NewClassID is wrong I will submit a patch to quickjs-ng