### PR TITLE
Misc fix and improvement quickjs-ng

### DIFF
--- a/bridge/jsb_bridge_module_loader.cpp
+++ b/bridge/jsb_bridge_module_loader.cpp
@@ -293,7 +293,7 @@ namespace jsb
 #endif
         }
 
-        // function (target: any, name: string, details: ScriptPropertyInfo): void;
+        // function (target: any, details: ScriptPropertyInfo): void;
         void _add_script_property(const v8::FunctionCallbackInfo<v8::Value> &info)
         {
             v8::Isolate* isolate = info.GetIsolate();

--- a/bridge/jsb_class_info.cpp
+++ b/bridge/jsb_class_info.cpp
@@ -218,7 +218,14 @@ namespace jsb
                     ScriptPropertyInfo property_info;
                     v8::Local<v8::Value> prop_name = obj->Get(context, jsb_name(environment, name)).ToLocalChecked();
                     property_info.name = impl::Helper::to_string(isolate, prop_name); // string
-                    property_info.type = (Variant::Type) obj->Get(context, jsb_name(environment, type)).ToLocalChecked()->Int32Value(context).ToChecked(); // int
+                    {
+                        auto type = obj->Get(context, jsb_name(environment, type)).ToLocalChecked()->Int32Value(context);
+                        if (type.IsNothing()) {
+                                JSB_LOG(Error, "Property type is invalid for `%s.%s'", p_class_info->js_class_name, property_info.name);
+                                continue; // Skip this export.
+                        }
+                        property_info.type = (Variant::Type) obj->Get(context, jsb_name(environment, type)).ToLocalChecked()->Int32Value(context).ToChecked(); // int
+                    }
                     property_info.hint = BridgeHelper::to_enum<PropertyHint>(context, obj->Get(context, jsb_name(environment, hint)), PROPERTY_HINT_NONE);
                     property_info.hint_string = impl::Helper::to_string(isolate, obj->Get(context, jsb_name(environment, hint_string)).ToLocalChecked());
                     property_info.usage = BridgeHelper::to_enum<PropertyUsageFlags>(context, obj->Get(context, jsb_name(environment, usage)), PROPERTY_USAGE_DEFAULT);

--- a/bridge/jsb_class_info.cpp
+++ b/bridge/jsb_class_info.cpp
@@ -229,6 +229,10 @@ namespace jsb
                     property_info.hint = BridgeHelper::to_enum<PropertyHint>(context, obj->Get(context, jsb_name(environment, hint)), PROPERTY_HINT_NONE);
                     property_info.hint_string = impl::Helper::to_string(isolate, obj->Get(context, jsb_name(environment, hint_string)).ToLocalChecked());
                     property_info.usage = BridgeHelper::to_enum<PropertyUsageFlags>(context, obj->Get(context, jsb_name(environment, usage)), PROPERTY_USAGE_DEFAULT);
+                    if (property_info.type == Variant::Type::OBJECT) {
+                        // TODO: make the string "class_name" a well known string ?
+                        property_info.class_name = impl::Helper::to_string(isolate, obj->Get(context, environment->get_string_value("class_name")).ToLocalChecked());
+                    }
 #ifdef TOOLS_ENABLED
                     if (v8::Local<v8::Value> val; !doc_map.IsEmpty() && doc_map->Get(p_context, prop_name).ToLocal(&val) && val->IsObject())
                     {

--- a/bridge/jsb_class_info.h
+++ b/bridge/jsb_class_info.h
@@ -108,7 +108,6 @@ namespace jsb
 
         StringName name;
 
-        //TODO class_name is needed if type is OBJECT
         StringName class_name;
 
         String hint_string;

--- a/internal/jsb_path_util.cpp
+++ b/internal/jsb_path_util.cpp
@@ -82,6 +82,7 @@ namespace jsb::internal
 
     String PathUtil::convert_typescript_path(const String& p_source_path)
     {
+#ifndef JSB_PREFER_QUICKJS_NG
         if (p_source_path.ends_with("." JSB_TYPESCRIPT_EXT))
         {
             jsb_checkf(p_source_path.begins_with("res://"), "can not proceed typescript sources not under the project directory");
@@ -90,6 +91,7 @@ namespace jsb::internal
                 + JSB_JAVASCRIPT_EXT);
             return replaced;
         }
+#endif
         return p_source_path;
     }
 

--- a/weaver-editor/templates/SCsub
+++ b/weaver-editor/templates/SCsub
@@ -44,6 +44,9 @@ else:
 
 # Template files 
 # the suffix should be `.ts`, but `editor/template_builders.py` hardcoded the delimiter with `.cs`
-templates_sources = Glob("*/*.cs")
+if env["use_quickjs_ng"]:
+    templates_sources = Glob("quickjs-ng/*/*.cs")
+else:
+    templates_sources = Glob("*/*.cs")
 
 env.Alias("editor_template_ts", [env.MakeGodotJSTemplateBuilder("templates.gen.h", templates_sources)])

--- a/weaver-editor/templates/quickjs-ng/CharacterBody2D/basic_movement.cs
+++ b/weaver-editor/templates/quickjs-ng/CharacterBody2D/basic_movement.cs
@@ -1,0 +1,37 @@
+// meta-description: Classic movement for gravity games (platformer, ...)
+
+const { _BASE_, ProjectSettings, Input, move_toward } = require("godot");
+
+const speed = 300;
+const jump_velocity = -400;
+
+// Get the gravity from the project settings to be synced with RigidBody nodes.
+const gravity = ProjectSettings.get_setting("physics/2d/default_gravity");
+
+exports.default = class _CLASS_ extends _BASE_ {
+    _physics_process(delta) {
+        let velocity = this.velocity;
+
+        // Add the gravity.
+        if (!this.is_on_floor()) {
+            velocity.y += gravity * delta;
+        }
+
+        // Handle Jump.
+        if (Input.is_action_just_pressed("ui_accept") && this.is_on_floor()) {
+            velocity.y = jump_velocity;
+        }
+
+        // Get the input direction and handle the movement/deceleration.
+        // As good practice, you should replace UI actions with custom gameplay actions.
+        let direction = Input.get_vector("ui_left", "ui_right", "ui_up", "ui_down");
+        if (Vector2.EQUAL(direction, Vector2.ZERO)) {
+            velocity.x = direction.x * speed;
+        } else {
+            velocity.x = move_toward(this.velocity.x, 0, speed);
+        }
+
+        this.velocity = velocity;
+        this.move_and_slide();
+    }
+};

--- a/weaver-editor/templates/quickjs-ng/Node/default.cs
+++ b/weaver-editor/templates/quickjs-ng/Node/default.cs
@@ -1,0 +1,14 @@
+// meta-description: Base template for Node with default Godot cycle methods
+
+const { _BASE_ } = require("godot");
+
+exports.default = class _CLASS_ extends _BASE_ {
+    // Called when the node enters the scene tree for the first time.
+    _ready() {
+
+    }
+
+    // Called every frame. 'delta' is the elapsed time since the previous frame.
+    _process(delta) {
+    }
+};

--- a/weaver-editor/templates/quickjs-ng/Object/empty.cs
+++ b/weaver-editor/templates/quickjs-ng/Object/empty.cs
@@ -1,0 +1,6 @@
+// meta-description: Empty template suitable for all Objects
+
+const { _BASE_ } = require("godot");
+
+exports.default = class _CLASS_ extends _BASE_ {
+};


### PR DESCRIPTION
Hello,

This patch suite follow my implementation of the "Your first 2D game" tutorial from Godot documentation, available [here](https://github.com/gschwind/dodge_the_creeps_godotjs.git).

The game is mostly functionnal, but still have missing feature:
 - Missing the await (I need to investigate more)
 - Failling to get item from PackedStringArray (maybe a braoder issue)

I also used some workaround and replacement:
 - quickjs-ng do not allow import syntax outside actual module loading, the workaround is to use require.
 - quickjs-ng do not support decorator, the workaround is to use internal function as replacement.
 - quickjs-ng does not support export/export default, thus I needed to use exports.default = class ... instead.

Best regards