### PR TITLE
fix: Godot 4.4 simple enums no longer have constants.

### DIFF
--- a/scripts/jsb.editor/src/jsb.editor.codegen.ts
+++ b/scripts/jsb.editor/src/jsb.editor.codegen.ts
@@ -1129,10 +1129,15 @@ export default class TSDCodeGen {
         if (cls.enums) {
             for (let enum_info of cls.enums) {
                 const enum_cg = class_ns_cg.enum_(enum_info.name);
+                let previousValue = -1;
                 for (let enumeration_name of enum_info.literals) {
-                    const value = cls.constants!.find(v => v.name == enumeration_name)!.value;
+                    const constant = cls.constants!.find(v => v.name == enumeration_name);
+                    const value = constant?.value ?? previousValue + 1;
                     enum_cg.element_(enumeration_name, value);
-                    ignored_consts.add(enumeration_name);
+                    if (constant) {
+                        ignored_consts.add(enumeration_name);
+                    }
+                    previousValue = value;
                 }
                 enum_cg.finish();
             }


### PR DESCRIPTION
In Godot 4.4, enums no longer have class level constants. This currently manifests in codegen of Godot types failing. This PR retains compatibility with <= 4.3 by continuing to look for constants, only if they're absent does it fall back to natural ordering.

Documentation:
https://docs.godotengine.org/en/stable/classes/class_vector2.html#constants
vs.
https://docs.godotengine.org/en/latest/classes/class_vector2.html#constants

Godot upstream change:
https://github.com/godotengine/godot/commit/03b05cf9acd69b7eeced919012c215b22cd901ab