### PR TITLE
Improved ergonomics GArray/GDictionary/Node

### DIFF
--- a/SCsub
+++ b/SCsub
@@ -237,7 +237,7 @@ def write_file(filename, ostream):
 def generate_method_code(output, methodname, indent, preset_defines):
     output.write(f"const char* GodotJSProjectPreset::{methodname}(const String& p_filename, size_t& r_len)\n")
     output.write("{\n")
-    output.write(indent+"static const char data[] = {\n")
+    output.write(indent+"static const unsigned char data[] = {\n")
     positions = {}
     cursor = 0
     for preset_define in preset_defines:
@@ -274,7 +274,7 @@ def generate_method_code(output, methodname, indent, preset_defines):
     for targetname in positions:
         start = positions[targetname][0]
         size = positions[targetname][1]
-        output.write(indent+f"if (p_filename == \"{targetname}\") {{ r_len = {size}; return data+{start}; }}\n")
+        output.write(indent+f"if (p_filename == \"{targetname}\") {{ r_len = {size}; return (const char *) data+{start}; }}\n")
     output.write(indent+"r_len = 0;\n")
     output.write(indent+"return nullptr;\n")
     output.write("}\n")

--- a/scripts/jsb.editor/src/jsb.editor.codegen.ts
+++ b/scripts/jsb.editor/src/jsb.editor.codegen.ts
@@ -110,7 +110,7 @@ const TypeMutations: Record<string, TypeMutation> = {
         intro: [
             "[Symbol.iterator](): IteratorObject<T>",
             "/** Returns a Proxy that targets this GArray but behaves similar to a JavaScript array. */",
-            `proxy(): { [Symbol.iterator](): IteratorObject<T>, [n: number]: T } & Pick<Array<T>, "length" | "push" | "pop" | "indexOf" | "includes">`,
+            `proxy(): GArrayProxy<T>`,
             "",
             "set_indexed(index: number, value: T): void",
             "get_indexed(index: number): T",
@@ -154,7 +154,7 @@ const TypeMutations: Record<string, TypeMutation> = {
         intro: [
             "[Symbol.iterator](): IteratorObject<{ key: any, value: any }>",
             "/** Returns a Proxy that targets this GDictionary but behaves similar to a regular JavaScript object. Values are exposed as enumerable properties, so Object.keys(), Object.entries() etc. will work. */",
-            "proxy(): { [K in keyof T & string]: T[K] }",
+            "proxy(): GDictionaryProxy<T>",
             "",
             "set_keyed<K extends keyof T>(key: K, value: T[K]): void",
             "get_keyed<K extends keyof T>(key: K): T[K]",

--- a/scripts/jsb.runtime/src/jsb.inject.ts
+++ b/scripts/jsb.runtime/src/jsb.inject.ts
@@ -1,14 +1,140 @@
+const proxyable_prototypes: any[] = [];
+
+const proxy_value = function(value: any) {
+    if (typeof value !== 'object' || value === null) {
+        return value;
+    }
+
+    const proto = Object.getPrototypeOf(value);
+    return proto && proxyable_prototypes.includes(proto)
+        ? value.proxy()
+        : value;
+};
 
 require("godot.typeloader").on_type_loaded("Array", function (type: any) {
+    proxyable_prototypes.push(type.prototype);
+
     type.prototype[Symbol.iterator] = function* () {
         let self = <any>this;
         for (let i = 0; i < self.size(); ++i) {
             yield self.get_indexed(i);
         }
-    }
+    };
+
+    // We're not going to try expose the whole Array API, we'll just be super minimalistic. If the user is after
+    // something more complex, it'll likely be more performant to spread the GArray into a JS array anyway.
+
+    const method_mapping: Partial<Record<string, string>> = {
+        pop: "pop_back",
+        indexOf: "find",
+        includes: "has",
+    };
+
+    const push = function(this: any /* GArray */, ...values: any[]) {
+        for (const value of values) {
+            this.push_back(value);
+        }
+        return this.size();
+    };
+
+    const handler: ProxyHandler<any> = {
+        get(target, p, receiver) {
+            if (typeof p !== 'string') {
+                return p === Symbol.iterator
+                    ? Reflect.get(target, Symbol.iterator).bind(target)
+                    : undefined;
+            }
+
+            const num = Number.parseInt(p);
+
+            if (!(num >= 0)) {
+                if (p === 'length') {
+                    return target.size();
+                } else if (p === 'push') {
+                    return push.bind(target);
+                }
+
+                const mapped = method_mapping[p];
+                return mapped && Reflect.get(target, mapped).bind(target);
+            }
+
+            if (num >= target.size()) {
+                return undefined;
+            }
+
+            return proxy_value(target.get(num));
+        },
+        getOwnPropertyDescriptor(target, p) {
+            if (typeof p !== 'string') {
+                return undefined;
+            }
+
+            const num = Number.parseInt(p);
+
+            if (!(num >= 0) || num >= target.size()) {
+                return undefined;
+            }
+
+            return {
+                configurable: true,
+                enumerable: true,
+                value: proxy_value(target.get(num)),
+                writable: true,
+            };
+        },
+        has(target, p) {
+            if (typeof p !== 'string') {
+                return false;
+            }
+
+            const num = Number.parseInt(p);
+
+            if (!(num >= 0)) {
+                return p === 'length' || !!method_mapping[p];
+            }
+
+            return num >= 0 && num < target.size();
+        },
+        isExtensible(target) {
+            return true;
+        },
+        ownKeys(target) {
+            const keys: string[] = [];
+            for (let i = 0; i < target.size(); i++) {
+                keys.push(i.toString());
+            }
+            return keys;
+        },
+        preventExtensions(target) {
+            return true;
+        },
+        set(target, p, newValue, receiver): boolean {
+            if (typeof p !== 'string') {
+                return false;
+            }
+
+            const num = Number.parseInt(p);
+
+            if (!(num >= 0) || num >= target.size()) {
+                return false;
+            }
+
+            target.set(num, newValue);
+            return true;
+        },
+        setPrototypeOf(target, v) {
+            return false;
+        },
+    };
+
+    type.prototype.proxy = function(this: any) {
+        return new Proxy(this, handler);
+    };
 });
 
 require("godot.typeloader").on_type_loaded("Dictionary", function (type: any) {
+    proxyable_prototypes.push(type.prototype);
+
     type.prototype[Symbol.iterator] = function* () {
         let self = <any>this;
         let keys = self.keys();
@@ -16,7 +142,70 @@ require("godot.typeloader").on_type_loaded("Dictionary", function (type: any) {
             const key = keys.get_indexed(i);
             yield { key: key, value: self.get_keyed(key) };
         }
-    }
+    };
+
+    const handler: ProxyHandler<any> = {
+        defineProperty(target, property, attributes) {
+            return false;
+        },
+        deleteProperty(target, p) {
+            return target.erase(p);
+        },
+        get(target, p, receiver) {
+            if (typeof p !== 'string') {
+                return undefined;
+            }
+            return proxy_value(target.get(p));
+        },
+        getOwnPropertyDescriptor(target, p) {
+            if (typeof p !== 'string') {
+                return undefined;
+            }
+
+            return {
+                configurable: true,
+                enumerable: true,
+                value: proxy_value(target.get(p)),
+                writable: true,
+            };
+        },
+        has(target, p) {
+            if (typeof p !== 'string') {
+                return false;
+            }
+
+            return target.has(p);
+        },
+        isExtensible(target) {
+            return true;
+        },
+        ownKeys(target) {
+            const keys: string[] = [];
+            for (const key of target.keys()) {
+                if (typeof key === "string") {
+                    keys.push(key);
+                }
+            }
+            return keys;
+        },
+        preventExtensions(target) {
+            return false;
+        },
+        set(target, p, newValue, receiver) {
+            if (typeof p !== 'string') {
+                return false;
+            }
+            target.set(p, newValue);
+            return true;
+        },
+        setPrototypeOf(target, v) {
+            return false;
+        },
+    };
+
+    type.prototype.proxy = function(this: any) {
+        return new Proxy(this, handler);
+    };
 });
 
 require("godot.typeloader").on_type_loaded("Callable", function (type: any) {
@@ -57,7 +246,7 @@ require("godot.typeloader").on_type_loaded("Signal", function (type: any) {
                     resolve(arguments[0]);
                     return;
                 }
-                // return as javascript array if more than one 
+                // return as javascript array if more than one
                 resolve(Array.from(arguments));
                 require("godot-jsb").internal.notify_microtasks_run();
             });

--- a/scripts/typings/godot.mix.d.ts
+++ b/scripts/typings/godot.mix.d.ts
@@ -186,4 +186,19 @@ declare module "godot" {
         as_promise(): Promise<T1>;
     }
 
+    type NodePathMap = { [K in string]?: Node };
+
+    type StaticNodePath<Map extends NodePathMap> = (keyof Map & string) | {
+        [K in keyof Map & string]: Map[K] extends Node<infer ChildMap>
+            ? `${K}/${StaticNodePath<ChildMap>}`
+            : never
+    }[keyof Map & string];
+
+    type ResolveNodePath<Map extends NodePathMap, Path extends string, Default = never> = Path extends keyof Map
+        ? Map[Path]
+        : Path extends `${infer Key extends keyof Map & string}/${infer SubPath}`
+            ? Map[Key] extends Node<infer ChildMap>
+                ? ResolveNodePath<ChildMap, SubPath, Default>
+                : Default
+            : Default;
 }

--- a/weaver-editor/jsb_editor_helper.cpp
+++ b/weaver-editor/jsb_editor_helper.cpp
@@ -1,10 +1,93 @@
 #include "jsb_editor_helper.h"
 
 #include "editor/gui/editor_toaster.h"
+#include "scene/resources/packed_scene.h"
+
+Dictionary GodotJSEditorHelper::_build_node_path_map(Node *node)
+{
+    Dictionary map;
+    Dictionary children;
+    map["class"] = node->get_class_name();
+    map["children"] = children;
+
+    int cc = node->get_child_count(true);
+
+    for (int i = 0; i < cc; i++)
+    {
+        Node *child = node->get_child(i, true);
+        children[child->get_name()] = _build_node_path_map(child);
+    }
+
+    return map;
+}
+
+// Similar logic to EditorNode::_dialog_display_load_error.
+void GodotJSEditorHelper::_log_scene_load_error(const String& p_file, Error p_error)
+{
+    if (p_error)
+    {
+        switch (p_error)
+        {
+            case ERR_CANT_OPEN:
+            {
+                JSB_LOG(Error, "Can't open file '%s'. The file could have been moved or deleted.", p_file.get_file());
+                break;
+            }
+            case ERR_PARSE_ERROR:
+            {
+                JSB_LOG(Error, "Error while parsing file '%s'.", p_file.get_file());
+                break;
+            }
+            case ERR_FILE_CORRUPT:
+            {
+                JSB_LOG(Error, "Scene file '%s' appears to be invalid/corrupt.", p_file.get_file());
+                break;
+            }
+            case ERR_FILE_NOT_FOUND:
+            {
+                JSB_LOG(Error, "Missing file '%s' or one of its dependencies.", p_file.get_file());
+                break;
+            }
+            case ERR_FILE_UNRECOGNIZED:
+            {
+                JSB_LOG(Error, "File '%s' is saved in a format that is newer than the formats supported by this version of Godot, so it can't be opened.", p_file.get_file());
+                break;
+            }
+            default:
+            {
+                JSB_LOG(Error, "Error while loading file '%s'.", p_file.get_file());
+                break;
+            }
+        }
+    }
+}
 
 void GodotJSEditorHelper::_bind_methods()
 {
     ClassDB::bind_static_method(jsb_typename(GodotJSEditorHelper), D_METHOD("show_toast", "text", "severity"), &GodotJSEditorHelper::show_toast);
+    ClassDB::bind_static_method(jsb_typename(GodotJSEditorHelper), D_METHOD("get_scene_nodes", "scene_path"), &GodotJSEditorHelper::get_scene_nodes);
+}
+
+Dictionary GodotJSEditorHelper::get_scene_nodes(const String &p_path)
+{
+    Error err;
+    Ref<PackedScene> scene_data = ResourceLoader::load(p_path, "", ResourceFormatLoader::CACHE_MODE_REPLACE, &err);
+
+    if (scene_data.is_null())
+    {
+        _log_scene_load_error(p_path, err);
+        return Dictionary();
+    }
+
+    Node *instantiated_scene = scene_data->instantiate(PackedScene::GEN_EDIT_STATE_INSTANCE);
+
+    if (!instantiated_scene)
+    {
+        JSB_LOG(Error, "Error instantiating scene from %s", p_path);
+        return Dictionary();
+    }
+
+    return _build_node_path_map(instantiated_scene);
 }
 
 void GodotJSEditorHelper::show_toast(const String& p_text, int p_severity)

--- a/weaver-editor/jsb_editor_helper.h
+++ b/weaver-editor/jsb_editor_helper.h
@@ -6,12 +6,18 @@ class GodotJSEditorHelper : public Object
 {
     GDCLASS(GodotJSEditorHelper, Object);
 
+private:
+
+    static Dictionary _build_node_path_map(Node *node);
+    static void _log_scene_load_error(const String& p_file, Error p_error);
+
 protected:
     static void _bind_methods();
 
 public:
     virtual ~GodotJSEditorHelper() override = default;
 
+    static Dictionary get_scene_nodes(const String &p_path);
     static void show_toast(const String& p_text, int p_severity);
 };
 

--- a/weaver-editor/jsb_editor_plugin.h
+++ b/weaver-editor/jsb_editor_plugin.h
@@ -53,6 +53,8 @@ private:
 
     std::shared_ptr<jsb::internal::Process> tsc_;
 
+    void _generate_edited_scene_dts(const String &p_path);
+
 protected:
     static void _bind_methods();
 
@@ -68,6 +70,8 @@ protected:
     static bool install_files(const Vector<jsb::weaver::InstallFileInfo>& p_files);
     static Vector<jsb::weaver::InstallFileInfo> filter_files(const Vector<jsb::weaver::InstallFileInfo>& p_files, int p_hint);
     static bool delete_file(const String& p_file);
+    static void get_all_scenes(EditorFileSystemDirectory *p_dir, Vector<String> &r_list);
+    static void generate_scenes_dts(const Vector<String>& p_paths);
 
 public:
     GodotJSEditorPlugin();
@@ -82,11 +86,13 @@ public:
     bool verify_ts_project() const;
     void _ignore_node_modules();
     void cleanup_invalid_files();
+    void generate_edited_scene_dts();
 
     // not really a singleton, but always get from `EditorNode` which assumed unique
     static GodotJSEditorPlugin* get_singleton();
 
     static void generate_godot_dts();
+    static void generate_all_scene_godot_dts();
     static void ignore_node_modules();
     static void collect_invalid_files(Vector<String>& r_invalid_files);
     static void collect_invalid_files(const String& p_path, Vector<String>& r_invalid_files);


### PR DESCRIPTION
I've improved the types for GArray, GDictionary and most notably Node. GArray and GDictionary also have a new `.proxy()` API.

_The first commit is a build bug fix. As far as runtime is concerned, it's a non-functional change. Basically compilation was failing if a byte (hex encoded) was generated with a value > 127, since it's beyond the upper limit of `char` data type._

# Node

Node's `get_node` API is now aware of the scene structure and the type of each node in each scene.

![CleanShot 2025-03-08 at 05 26 26@2x](https://github.com/user-attachments/assets/a9c5f4d2-2609-4135-aafe-e5401c27f962)

It's worth noting, this isn't just auto-complete, the scene hierarchy is fully typed:

![CleanShot 2025-03-09 at 00 54 32@2x](https://github.com/user-attachments/assets/cbd5c136-90d0-4022-b7a0-50556cdad620)

This is opt-in, such that it's non-breaking. Basically `Node` and all Node sub-classes now _optionally_ take a generic parameter:

```ts
Node<Map extends Record<string, Node> = {}>
```

However, in the typical case, it'd be tedious to create these by hand and keep them in sync with your scenes. Fortunately, GodotJS will generate an appropriate Map for you. When you save a scene (or when you generate all `.d.ts`) in your `typings` sub-directory a `.nodes.d.ts` will be generated for each scene. They look something like:

```ts 
declare module "godot" {
    interface SceneNodes {
        "scenes/card_3d.tscn": {
            CardMesh: Node3D<
                {
                    CardBackMesh: MeshInstance3D<{}>,
                    CardFrontMesh: MeshInstance3D<{}>,
                }
            >,
            StaticBody3D: StaticBody3D<
                {
                    CollisionShape3D: CollisionShape3D<{}>,
                }
            >,
            Node3D: Node3D<{}>,
        },
    }
}
```

These are all separate files so we can efficiently generate one at a time. However, we take advantage of TS interface merging on `SceneNodes`. The way you use this in your custom class is:

```
export default class Card3D extends Node3D<SceneNodes['scenes/card_3d.tscn']> {
```

If the same script is being applied to multiple scenes, you can pass in a union. Or if you're generating/modifying scenes dynamically, you can still benefit from static typing, you'd simply produce your own `Map` following whatever structure you desire. `Map` is optional, if you don't specify it, you get the old functionality.

## TODO: NodePath

I've currently only implemented this logic for JS strings, not `NodePath`. It'd be reasonably straight-forward to get this working with `NodePath` too.

# GDictionary

GDictionary now (optionally) takes a generic type:

```ts
class GDictionary<T = Record<any, any>>
```

Function types have been updated to make use of this type.

However, the biggest addition is the introduction of `.proxy()` method on `GDictionary`.

```ts
/** Returns a Proxy that targets this GDictionary but behaves similar to a regular JavaScript object. Values are exposed as enumerable properties, so Object.keys(), Object.entries() etc. will work. */
proxy(): { [K in keyof T & string]: T[K] }
``` 

This allows you to read and write to a GDictionary using regular JS syntax. However, importantly, these properties are enumerable, which means everything from `JSON.stringify` to spreading will work.

```ts
const g_dict = new GDictionary<{ typed: string, now: number }>();
const dict_proxy = g_dict.proxy();

dict_proxy.typed = 'thing';
dict_proxy.now = 2;

for (const [key, value] of Object.entries(dict_proxy)) {
  console.log(`Dictionary iterated key: ${key}, value: ${value}`);
}
```

My initial implementation for this kind of logic was actually in C++ using v8's NamedPropertyHandler. This basically changed GDictionary's default API and worked reasonably well _except_:

1. It would have caused issues when dealing with GDictionary that contain non-string keys.
2. It was v8 only. The other engines don't actually seem to have an equivalent. Well, I guess they do, it's `Proxy`, which is what I've gone with now.

# GArray

Types have been cleaned up a little. Actually, the type generation code had a lot of TODOs, I've cleaned up all those such that most of (all?) the type customizations are defined in the one place.

I've also added a `.proxy()` method to `GArray` similar to `GDictionary`. This returns `Proxy` object with the signature:

```ts
{ [Symbol.iterator](): IteratorObject<T>, [n: number]: T } & Pick<Array<T>, "length" | "push" | "pop" | "indexOf" | "includes">
```

Basically this allows you to access a GArray using the same syntax you'd use to access a regular JavaScript array. I haven't tried to support the entire JS Array API, I've just added a very minimalistic API. If a user is wanting to do something more complex, then going back and forth across the JS <-> C++ boundary probably isn't very efficient anyway. Since the properties are enumerable, obtaining a JS array from a `GArray` is now as simple as:

```ts
[...g_arr.proxy()]
```

Whilst you could previously, and still can:

```ts
[...g_arr]
```

The latter won't work well with nested structures, where as the spreading the `.proxy()` will.

```ts
[JS] JSON.stringify([...g_arr]): [1,"bye","3 no more",{"0":{}},5]
[JS] JSON.stringify([...g_arr.proxy()]): [1,"bye","3 no more",[4,"four",{}],5]
```
**Note:** `[...g_arr.proxy()]` is still a shallow copy i.e. `[...g_arr.proxy()][3][0] = 10` will update the original nested GArray, not a copy. Only the outermost array is a new copy.