### PR TITLE
fix: unlock AddressScope when reassigned

### DIFF
--- a/internal/jsb_sarray.h
+++ b/internal/jsb_sarray.h
@@ -68,7 +68,17 @@ namespace jsb::internal
             AddressScope& operator=(const AddressScope&) = delete;
 
             AddressScope(AddressScope&& p_other) noexcept { container_ = p_other.container_; p_other.container_ = nullptr; }
-            AddressScope& operator=(AddressScope&& p_other) noexcept { container_ = p_other.container_; p_other.container_ = nullptr; return *this; }
+
+            AddressScope& operator=(AddressScope&& p_other) noexcept
+            {
+                if (this != &p_other)
+                {
+                    if (container_) container_->unlock_address();
+                    container_ = p_other.container_;
+                    p_other.container_ = nullptr;
+                }
+                return *this;
+            }
         };
 
         template<typename S>


### PR DESCRIPTION
I'm going to try submit several smaller PRs rather than giant ones!

This is a _super_ minor change. Just another place where reassignment doesn't unlock the previously held lock. Honestly, I'm not even sure what the intended purpose of `AddressScope` is 😅.