### PR TITLE
fix: Non-editor build (TOOLS_ENABLED 0)

### DIFF
--- a/internal/jsb_naming_util.cpp
+++ b/internal/jsb_naming_util.cpp
@@ -272,6 +272,7 @@ namespace jsb::internal
 
 	List<StringName> NamingUtil::get_exposed_class_list()
 	{
+#ifdef TOOLS_ENABLED
 		const PackedStringArray ignored_classes = internal::Settings::get_ignored_classes();
 		const int ignored_classes_num = (int) ignored_classes.size();
 		HashSet<StringName> ignored_classes_set(ignored_classes_num);
@@ -280,6 +281,7 @@ namespace jsb::internal
 		{
 			ignored_classes_set.insert(ignored_classes[i]);
 		}
+#endif
 
 		List<StringName> all_class_names;
 		ClassDB::get_class_list(&all_class_names);
@@ -290,11 +292,13 @@ namespace jsb::internal
 		{
 			StringName class_name = *it;
 
+#ifdef TOOLS_ENABLED
 			if (ignored_classes_set.has(class_name))
 			{
 				JSB_LOG(Verbose, "Ignoring class '%s' because it's in the ignored classes list", class_name);
 				continue;
 			}
+#endif
 
 			ClassDB::APIType api_type = ClassDB::get_api_type(class_name);
 


### PR DESCRIPTION
I was writing some `TOOLS_ENABLED` only code and it occurred to me I haven't actually tried a _non-tools_ build in a while. It seems I broke the build because I consumed `internal::Settings::get_ignored_classes()` without `TOOLS_ENABLED` guards. So this PR rectifies the situation.

That said, is it actually intended that ignored classes are an editor only feature? I'm not sure how people are using the feature, but I can see this being unexpected, say if someone was attempting to use the feature as a form of sandboxing. Do you happen to know if anyone is actually using the feature, and for what purpose?