### PR TITLE
feat: Codegen for resources

### DIFF
--- a/internal/jsb_settings.cpp
+++ b/internal/jsb_settings.cpp
@@ -16,6 +16,8 @@ namespace jsb::internal
     static constexpr char kEdIgnoredClasses[] =     JSB_MODULE_NAME_STRING "/codegen/ignored_classes";
     static constexpr char kEdAutogenSceneDTSOnSave[] =     JSB_MODULE_NAME_STRING "/codegen/autogen_scene_dts_on_save";
     static constexpr char kEdGenSceneDTS[] =     JSB_MODULE_NAME_STRING "/codegen/generate_scene_dts";
+    static constexpr char kEdAutogenResourceDTSOnSave[] =     JSB_MODULE_NAME_STRING "/codegen/autogen_resource_dts_on_save";
+    static constexpr char kEdGenResourceDTS[] =     JSB_MODULE_NAME_STRING "/codegen/generate_resource_dts";
 #endif
 
     // use unnecessary first category layer (runtime and editor) to make the second layer shown as sections in project settings
@@ -57,6 +59,8 @@ namespace jsb::internal
                 _EDITOR_DEF(kEdIgnoredClasses, PackedStringArray(), false);
                 _EDITOR_DEF(kEdGenSceneDTS, true, false);
                 _EDITOR_DEF(kEdAutogenSceneDTSOnSave, true, false);
+                _EDITOR_DEF(kEdGenResourceDTS, true, false);
+                _EDITOR_DEF(kEdAutogenResourceDTSOnSave, true, false);
             }
         }
         return inited;
@@ -118,6 +122,18 @@ namespace jsb::internal
     {
         init_editor_settings();
         return EDITOR_GET(kEdGenSceneDTS);
+    }
+
+    bool Settings::get_autogen_resource_dts_on_save()
+    {
+        init_editor_settings();
+        return EDITOR_GET(kEdAutogenResourceDTSOnSave);
+    }
+
+    bool Settings::get_gen_resource_dts()
+    {
+        init_editor_settings();
+        return EDITOR_GET(kEdGenResourceDTS);
     }
 #endif
 

--- a/internal/jsb_settings.h
+++ b/internal/jsb_settings.h
@@ -46,6 +46,8 @@ namespace jsb::internal
         static PackedStringArray get_ignored_classes();
         static bool get_autogen_scene_dts_on_save();
         static bool get_gen_scene_dts();
+        static bool get_autogen_resource_dts_on_save();
+        static bool get_gen_resource_dts();
 #endif
     };
 }

--- a/internal/jsb_string_names.def.h
+++ b/internal/jsb_string_names.def.h
@@ -61,7 +61,13 @@ DEF(transfer)
 DEF(close)
 
 // editor
+#ifdef TOOLS_ENABLED
 DEF(arguments)
+DEF(base)
 DEF(codegen)
+DEF(index)
 DEF(node)
 DEF(properties)
+DEF(resource)
+DEF(GodotJSScript)
+#endif

--- a/scripts/typings/godot.generated.d.ts
+++ b/scripts/typings/godot.generated.d.ts
@@ -2,8 +2,10 @@
 // godot.xxx.d.ts files will be generated in a target project.
 
 ///<reference path="godot.mix.d.ts" />
+
 declare module "godot" {
     class Node<Map extends Record<string, Node> = {}> extends Object { }
+    class Resource { }
     class GArray<T = any> {
         proxy<Write extends boolean = false>(): Write extends true ? GArrayProxy<T> : GArrayReadProxy<T>;
         get_indexed(index: number): T

--- a/weaver-editor/jsb_editor_helper.cpp
+++ b/weaver-editor/jsb_editor_helper.cpp
@@ -10,6 +10,7 @@
 // The following enums must be kept in sync with jsb.editor.codegen.ts
 enum class CodeGenType {
     ScriptNodeTypeDescriptor,
+    ScriptResourceTypeDescriptor,
 };
 enum class DescriptorType {
     Godot,
@@ -24,93 +25,165 @@ enum class DescriptorType {
     Conditional,
     Tuple,
     Infer,
-    Mapped
+    Mapped,
+    Indexed,
 };
 
-Dictionary GodotJSEditorHelper::_build_node_type_descriptor(jsb::JSEnvironment& p_env, Node *node)
+bool GodotJSEditorHelper::_request_codegen(jsb::JSEnvironment& p_env, GodotJSScript* p_script, const Dictionary& p_request, Dictionary& p_result)
 {
+    v8::Isolate* isolate = p_env->get_isolate();
+    v8::Local<v8::Context> context = p_env->get_context();
+
+    p_script->load_module_if_missing();
+    String module_id = p_script->get_module_id();
+    jsb::JavaScriptModule* module = p_env->get_module_cache().find(module_id);
+
+    if (module == nullptr)
+    {
+        JSB_LOG(Warning, "Codegen failed to load module '%s'.", module_id);
+        return false;
+    }
+
+    if (module->exports.IsEmpty())
+    {
+        return false;
+    }
+
+    v8::Local<v8::Value> module_exports = module->exports.Get(isolate);
+
+    if (module_exports.IsEmpty() || !module_exports->IsObject())
+    {
+        return false;
+    }
+
+    const v8::Local<v8::Value> codegen_func_val = module_exports.As<v8::Object>()->Get(context, jsb_name(p_env, codegen)).ToLocalChecked();
+
+    if (codegen_func_val.IsEmpty() || !codegen_func_val->IsFunction())
+    {
+        return false;
+    }
+
+    const v8::Local<v8::Function> codegen_func = codegen_func_val.As<v8::Function>();
+    v8::Local<v8::Value> codegen_request_val;
+
+    if (!jsb::TypeConvert::gd_var_to_js(isolate, context, p_request, codegen_request_val))
+    {
+        return false;
+    }
+
+    v8::Local<v8::Value> argv[] = { codegen_request_val };
+
+    const v8::MaybeLocal<v8::Value> maybe_result = codegen_func->Call(context, v8::Undefined(isolate), std::size(argv), argv);
+    v8::Local<v8::Value> result_val;
+    Variant result;
+
+    if (!maybe_result.ToLocal(&result_val) || !jsb::TypeConvert::js_to_gd_var(isolate, context, result_val, Variant::Type::DICTIONARY, result))
+    {
+        return false;
+    }
+
+    p_result = result;
+    return true;
+}
+
+Dictionary GodotJSEditorHelper::_build_node_type_descriptor(jsb::JSEnvironment& p_env, Node* p_node, const String& scene_resource_path)
+{
+    Dictionary descriptor;
     Dictionary children;
-    int child_count = node->get_child_count(true);
+    int child_count = p_node->get_child_count(true);
 
     for (int i = 0; i < child_count; i++)
     {
-        Node* child = node->get_child(i, true);
+        Node* child = p_node->get_child(i, true);
         children[child->get_name()] = _build_node_type_descriptor(p_env, child);
     }
 
-    ScriptInstance* script_instance = node->get_script_instance();
-    GodotJSScript* script = script_instance ? Object::cast_to<GodotJSScript>(*script_instance->get_script()) : nullptr;
+    ScriptInstance* script_instance = p_node->get_script_instance();
+    GodotJSScript* script = script_instance != nullptr ? Object::cast_to<GodotJSScript>(*script_instance->get_script()) : nullptr;
 
-    if (script)
+    if (script != nullptr)
     {
-        v8::Isolate* isolate = p_env->get_isolate();
-        v8::Local<v8::Context> context = p_env->get_context();
+        Dictionary codegen_request;
+        codegen_request[jsb_string_name(type)] = (int32_t) CodeGenType::ScriptNodeTypeDescriptor;
+        codegen_request[jsb_string_name(node)] = p_node;
+        codegen_request[jsb_string_name(children)] = children;
 
-        script->load_module_if_missing();
-        String module_id = script->get_module_id();
-        jsb::JavaScriptModule* module = p_env->get_module_cache().find(module_id);
-
-        if (module == nullptr)
+        if (!_request_codegen(p_env, script, codegen_request, descriptor))
         {
-            JSB_LOG(Warning, "Codegen failed to load module '%s'.", module_id);
+            descriptor.clear();
         }
+    }
 
-        v8::Local<v8::Value> module_exports;
-
-        if (module != nullptr && !module->exports.IsEmpty())
+    if (descriptor.is_empty())
+    {
+        // By default, only scene (and sub-scene) roots are typed with a user defined type. This ensures that classes are
+        // able to use SceneNodes in their type declaration without illegally referencing their own type. Users can use
+        // codegen to override alter behavior.
+        if (script == nullptr || p_node->get_scene_file_path().is_empty() || GodotJSScriptLanguage::get_singleton()->is_global_class_generic(script->get_path()))
         {
-            module_exports = module->exports.Get(isolate);
+            Dictionary object_literal;
+            object_literal[jsb_string_name(type)] = (int32_t) DescriptorType::ObjectLiteral;
+            object_literal[jsb_string_name(properties)] = children;
+
+            Array generic_arguments;
+            generic_arguments.push_back(object_literal);
+
+            descriptor[jsb_string_name(type)] = (int32_t) DescriptorType::Godot;
+            descriptor[jsb_string_name(name)] = jsb::internal::NamingUtil::get_class_name(p_node->get_class_name());
+            descriptor[jsb_string_name(arguments)] = generic_arguments;
         }
-
-        if (!module_exports.IsEmpty() && module_exports->IsObject())
+        else
         {
-            const v8::Local<v8::Value> codegen_func_val = module_exports.As<v8::Object>()->Get(context, jsb_name(p_env, codegen)).ToLocalChecked();
+            descriptor[jsb_string_name(type)] = (int32_t) DescriptorType::User;
+            descriptor[jsb_string_name(name)] = script->get_global_name();
+            descriptor[jsb_string_name(resource)] = script->get_path();
+        }
+    }
 
-            if (!codegen_func_val.IsEmpty() && codegen_func_val->IsFunction())
+    // Optionally replace children literal with SceneNodes["path/to/scene.tscn"]
+    if (!scene_resource_path.is_empty())
+    {
+        Variant arguments_var = descriptor[jsb_string_name(arguments)];
+
+        if (arguments_var.is_array())
+        {
+            Array arguments = arguments_var;
+            int argument_count = arguments.size();
+
+            Dictionary children_descriptor;
+            children_descriptor[jsb_string_name(type)] = (int32_t) DescriptorType::ObjectLiteral;
+            children_descriptor[jsb_string_name(properties)] = children;
+
+            for (int i = 0; i < argument_count; i++)
             {
-                const v8::Local<v8::Function> codegen_func = codegen_func_val.As<v8::Function>();
+                Variant argument = arguments[i];
 
-                Dictionary codegen_request;
-                codegen_request[jsb_string_name(type)] = (int32_t) CodeGenType::ScriptNodeTypeDescriptor;
-                codegen_request[jsb_string_name(node)] = node;
-                codegen_request[jsb_string_name(children)] = children;
-
-                v8::Local<v8::Value> codegen_request_val;
-
-                if (jsb::TypeConvert::gd_var_to_js(isolate, context, codegen_request, codegen_request_val))
+                if (argument.get_type() == Variant::Type::DICTIONARY && Dictionary(argument) == children_descriptor)
                 {
-                    v8::Local<v8::Value> argv[] = { codegen_request_val };
+                    Dictionary scene_nodes;
+                    scene_nodes[jsb_string_name(type)] = (int32_t) DescriptorType::Godot;
+                    scene_nodes[jsb_string_name(name)] = "SceneNodes";
 
-                    const v8::MaybeLocal<v8::Value> maybe_result = codegen_func->Call(context, v8::Undefined(isolate), std::size(argv), argv);
-                    v8::Local<v8::Value> result_val;
-                    Variant result;
+                    Dictionary string_literal;
+                    string_literal[jsb_string_name(type)] = (int32_t) DescriptorType::StringLiteral;
+                    string_literal[jsb_string_name(value)] = scene_resource_path.substr(6); // Remove leading res://
 
-                    if (maybe_result.ToLocal(&result_val) && jsb::TypeConvert::js_to_gd_var(isolate, context, result_val, Variant::Type::DICTIONARY, result))
-                    {
-                        return result;
-                    }
+                    Dictionary indexed_scene_nodes;
+                    indexed_scene_nodes[jsb_string_name(type)] = (int32_t) DescriptorType::Indexed;
+                    indexed_scene_nodes[jsb_string_name(base)] = scene_nodes;
+                    indexed_scene_nodes[jsb_string_name(index)] = string_literal;
+
+                    arguments[i] = indexed_scene_nodes;
                 }
             }
         }
     }
 
-    Dictionary object_literal;
-    object_literal[jsb_string_name(type)] = (int32_t) DescriptorType::ObjectLiteral;
-    object_literal[jsb_string_name(properties)] = children;
-
-    Array generic_arguments;
-    generic_arguments.push_back(object_literal);
-
-    Dictionary default_descriptor;
-    default_descriptor[jsb_string_name(name)] = node->get_class_name();
-    default_descriptor[jsb_string_name(type)] = (int32_t) DescriptorType::Godot;
-    default_descriptor[jsb_string_name(arguments)] = generic_arguments;
-
-    return default_descriptor;
+    return descriptor;
 }
 
 // Similar logic to EditorNode::_dialog_display_load_error.
-void GodotJSEditorHelper::_log_scene_load_error(const String& p_file, Error p_error)
+void GodotJSEditorHelper::_log_load_error(const String &p_file, const String &p_type, Error p_error)
 {
     if (p_error)
     {
@@ -128,7 +201,7 @@ void GodotJSEditorHelper::_log_scene_load_error(const String& p_file, Error p_er
             }
             case ERR_FILE_CORRUPT:
             {
-                JSB_LOG(Error, "Scene file '%s' appears to be invalid/corrupt.", p_file.get_file());
+                JSB_LOG(Error, "%s file '%s' appears to be invalid/corrupt.", p_type, p_file.get_file());
                 break;
             }
             case ERR_FILE_NOT_FOUND:
@@ -153,7 +226,76 @@ void GodotJSEditorHelper::_log_scene_load_error(const String& p_file, Error p_er
 void GodotJSEditorHelper::_bind_methods()
 {
     ClassDB::bind_static_method(jsb_typename(GodotJSEditorHelper), D_METHOD("show_toast", "text", "severity"), &GodotJSEditorHelper::show_toast);
+    ClassDB::bind_static_method(jsb_typename(GodotJSEditorHelper), D_METHOD("get_resource_type_descriptor", "resource_path"), &GodotJSEditorHelper::get_resource_type_descriptor);
     ClassDB::bind_static_method(jsb_typename(GodotJSEditorHelper), D_METHOD("get_scene_nodes", "scene_path"), &GodotJSEditorHelper::get_scene_nodes);
+}
+
+Dictionary GodotJSEditorHelper::get_resource_type_descriptor(const String& p_path)
+{
+    Dictionary descriptor;
+    Error err;
+    Ref<Resource> resource = ResourceLoader::load(p_path, "", ResourceFormatLoader::CACHE_MODE_REUSE, &err);
+
+    if (resource.is_null())
+    {
+        _log_load_error(p_path, "Resource", err);
+        return descriptor;
+    }
+
+	PackedScene* scene = Object::cast_to<PackedScene>(resource.ptr());
+
+    if (scene)
+    {
+        Node* instantiated_scene = scene->instantiate(PackedScene::GEN_EDIT_STATE_INSTANCE);
+        if (!instantiated_scene)
+        {
+            JSB_LOG(Error, "Error instantiating scene from %s", p_path);
+            return descriptor;
+        }
+
+        jsb::JSEnvironment env(instantiated_scene->get_scene_file_path(), true);
+
+        Array generic_arguments;
+        generic_arguments.push_back(_build_node_type_descriptor(env, instantiated_scene, p_path));
+
+        descriptor[jsb_string_name(type)] = (int32_t) DescriptorType::Godot;
+        descriptor[jsb_string_name(name)] = "PackedScene";
+        descriptor[jsb_string_name(arguments)] = generic_arguments;
+
+        return descriptor;
+    }
+
+    ScriptInstance* script_instance = resource->get_script_instance();
+    GodotJSScript* script = script_instance != nullptr ? Object::cast_to<GodotJSScript>(*script_instance->get_script()) : nullptr;
+
+    if (script != nullptr)
+    {
+        jsb::JSEnvironment env(resource->get_path(), true);
+
+        Dictionary codegen_request;
+        codegen_request[jsb_string_name(type)] = (int32_t) CodeGenType::ScriptResourceTypeDescriptor;
+        codegen_request[jsb_string_name(resource)] = resource;
+
+        if (_request_codegen(env, script, codegen_request, descriptor))
+        {
+            return descriptor;
+        }
+    }
+
+    if (script == nullptr || GodotJSScriptLanguage::get_singleton()->is_global_class_generic(script->get_path()))
+    {
+        const StringName& resource_class = resource->get_class_name();
+        descriptor[jsb_string_name(type)] = (int32_t) DescriptorType::Godot;
+        descriptor[jsb_string_name(name)] = resource_class == jsb_string_name(GodotJSScript) ? "Script" : jsb::internal::NamingUtil::get_class_name(resource_class);
+    }
+    else
+    {
+        descriptor[jsb_string_name(type)] = (int32_t) DescriptorType::User;
+        descriptor[jsb_string_name(name)] = ResourceLoader::get_resource_script_class(p_path);
+        descriptor[jsb_string_name(resource)] = script->get_path();
+    }
+
+    return descriptor;
 }
 
 Dictionary GodotJSEditorHelper::get_scene_nodes(const String& p_path)
@@ -163,7 +305,7 @@ Dictionary GodotJSEditorHelper::get_scene_nodes(const String& p_path)
 
     if (scene_data.is_null())
     {
-        _log_scene_load_error(p_path, err);
+        _log_load_error(p_path, "Resource", err);
         return Dictionary();
     }
 
@@ -184,7 +326,7 @@ Dictionary GodotJSEditorHelper::get_scene_nodes(const String& p_path)
 
     for (int i = 0; i < child_count; i++)
     {
-        Node *child = instantiated_scene->get_child(i, true);
+        Node* child = instantiated_scene->get_child(i, true);
         nodes[child->get_name()] = _build_node_type_descriptor(env, child);
     }
 

--- a/weaver-editor/jsb_editor_helper.h
+++ b/weaver-editor/jsb_editor_helper.h
@@ -8,8 +8,9 @@ class GodotJSEditorHelper : public Object
 
 private:
 
-    static Dictionary _build_node_type_descriptor(jsb::JSEnvironment& p_env, Node *node);
-    static void _log_scene_load_error(const String& p_file, Error p_error);
+    static bool _request_codegen(jsb::JSEnvironment& p_env, GodotJSScript* p_script, const Dictionary& p_request, Dictionary& p_result);
+    static Dictionary _build_node_type_descriptor(jsb::JSEnvironment& p_env, Node* p_node, const String& scene_resource_path = String());
+    static void _log_load_error(const String &p_file, const String &p_type, Error p_error);
 
 protected:
     static void _bind_methods();
@@ -17,6 +18,7 @@ protected:
 public:
     virtual ~GodotJSEditorHelper() override = default;
 
+    static Dictionary get_resource_type_descriptor(const String &p_path);
     static Dictionary get_scene_nodes(const String &p_path);
     static void show_toast(const String& p_text, int p_severity);
 };

--- a/weaver-editor/jsb_editor_plugin.h
+++ b/weaver-editor/jsb_editor_plugin.h
@@ -53,7 +53,8 @@ private:
 
     std::shared_ptr<jsb::internal::Process> tsc_;
 
-    void _generate_edited_scene_dts(const String &p_path);
+    void _generate_edited_scene_dts(const String& p_path);
+    void _generate_edited_resource_dts(const Ref<Resource>& p_resource);
 
 protected:
     static void _bind_methods();
@@ -70,8 +71,10 @@ protected:
     static bool install_files(const Vector<jsb::weaver::InstallFileInfo>& p_files);
     static Vector<jsb::weaver::InstallFileInfo> filter_files(const Vector<jsb::weaver::InstallFileInfo>& p_files, int p_hint);
     static bool delete_file(const String& p_file);
-    static void get_all_scenes(EditorFileSystemDirectory *p_dir, Vector<String> &r_list);
-    static void generate_scenes_dts(const Vector<String>& p_paths);
+    static void get_all_scenes(EditorFileSystemDirectory* p_dir, Vector<String>& r_list);
+    static void get_all_resources(EditorFileSystemDirectory* p_dir, Vector<String>& r_list);
+    static void generate_scene_nodes_dts(const Vector<String>& p_paths);
+    static void generate_resource_dts(const Vector<String>& p_paths);
 
 public:
     GodotJSEditorPlugin();
@@ -92,7 +95,8 @@ public:
     static GodotJSEditorPlugin* get_singleton();
 
     static void generate_godot_dts();
-    static void generate_all_scene_godot_dts();
+    static void generate_all_scene_nodes_dts();
+    static void generate_all_resource_dts();
     static void ignore_node_modules();
     static void collect_invalid_files(Vector<String>& r_invalid_files);
     static void collect_invalid_files(const String& p_path, Vector<String>& r_invalid_files);

--- a/weaver-editor/jsb_export_plugin.cpp
+++ b/weaver-editor/jsb_export_plugin.cpp
@@ -2,13 +2,15 @@
 
 #define JSB_EXPORTER_LOG(Severity, Format, ...) JSB_LOG_IMPL(JSExporter, Severity, Format, ##__VA_ARGS__)
 
+HashSet<String> GodotJSExportPlugin::ignored_paths_ {
+    String("res://jsconfig.json"),
+    String("res://tsconfig.json"),
+    String("res://package.json"),
+    String("res://package-lock.json"),
+};
+
 GodotJSExportPlugin::GodotJSExportPlugin() : super()
 {
-    // explicitly ignored files (not used by runtime)
-    ignored_paths_.insert("res://jsconfig.json");
-    ignored_paths_.insert("res://tsconfig.json");
-    ignored_paths_.insert("res://package.json");
-    ignored_paths_.insert("res://package-lock.json");
     env_ = GodotJSScriptLanguage::get_singleton()->get_environment();
     jsb_check(env_);
 }

--- a/weaver-editor/jsb_export_plugin.h
+++ b/weaver-editor/jsb_export_plugin.h
@@ -19,6 +19,8 @@ public:
     virtual String get_name() const override;
     virtual bool supports_platform(const Ref<EditorExportPlatform>& p_export_platform) const override;
 
+    static const HashSet<String> get_ignored_paths() { return ignored_paths_; }
+
 protected:
     virtual void _export_begin(const HashSet<String>& p_features, bool p_debug, const String& p_path, int p_flags) override;
     virtual void _export_file(const String& p_path, const String& p_type, const HashSet<String>& p_features) override;
@@ -26,11 +28,12 @@ protected:
     virtual PackedStringArray _get_export_features(const Ref<EditorExportPlatform>& p_export_platform, bool p_debug) const override;
 
 private:
+    static HashSet<String> ignored_paths_;
+
     bool export_compiled_script(const String& p_path);
     bool export_module_files(const jsb::JavaScriptModule& p_module);
     bool export_raw_file(const String& p_path);
 
-    HashSet<String> ignored_paths_;
     HashSet<String> exported_paths_;
     std::shared_ptr<jsb::Environment> env_;
 };

--- a/weaver/jsb_script_language.h
+++ b/weaver/jsb_script_language.h
@@ -106,9 +106,7 @@ private:
     ScriptCallProfileInfoMap profile_info_map_;
 #endif
 
-    // [TS] matches 'export default class ClassName extends BaseName {'
     Ref<RegEx> ts_class_name_matcher_;
-    Ref<RegEx> ts_class_name_tool_matcher_;
 
     // [JS] export & declare in two lines, matches 'class ClassName extends BaseName' + 'exports.default = ClassName'
     Ref<RegEx> js_class_name_matcher2_;
@@ -133,6 +131,8 @@ public:
     void scan_external_changes();
 
     void add_script_call_profile_info(const String& p_path, const StringName& p_class, const StringName& p_method, uint64_t p_time);
+
+    bool is_global_class_generic(const String &p_path) const;
 
     template<size_t N>
     jsb::JSValueMove eval_source(const char (&p_code)[N], Error& r_err)


### PR DESCRIPTION
# Resource Types

Implemented similarly to scene node types.

Additionally includes:

- fix: `@Tool` annotation (for camel-case binding mode), as opposed to `@tool` with original bindings (regex was updated).
- Code clean-up. Fixed some tabs that should be spaces and some code consistency issues I'd introduced in past commits.

## Completion

`ResourceLoader.load()` will now autocomplete e.g.

![CleanShot 2025-04-04 at 01 51 02@2x](https://github.com/user-attachments/assets/872ecff3-23f0-4b11-ae64-653508c829b8)

## .gen.d.ts files

Similarly to scenes, each resource has a generated `.gen.d.ts file` in the `typings/` sub-directory.

For example, a `hmm.tres` file for a custom Resource whose script looks like:

```ts
export default class LineCardLayout extends CardLayout {
```
will have the following `hmm.tres.gen.d.ts` generated:
```ts
import LineCardLayout from "../../../src/layouts/line-card-layout";
declare module "godot" {
    interface ResourceTypes {
        "res://scenes/example/hmm.tres": LineCardLayout;
    }
}
```

## ResourceLoader.load

Now when you write code to load a resource with a string literal, the type is known:

![CleanShot 2025-04-04 at 01 54 15@2x](https://github.com/user-attachments/assets/f88f6920-6f62-43c6-b4f8-47350cd48de8)

Built-in resource types are also typed as expected:

![CleanShot 2025-04-04 at 02 04 43@2x](https://github.com/user-attachments/assets/62ec8dd7-33e7-4da8-a86f-64ec0989bbbc)

Unknown/non-literal resources will fallback to being typed as `Resource`, mimicking the old behavior.

## Scenes

We have special case handling for scenes.

![CleanShot 2025-04-04 at 01 07 44@2x](https://github.com/user-attachments/assets/0a4a27ff-89d0-4cb0-81a1-4bc1d4d40064)

In the example above, no explicit types are provided, but the instantiated scene is known to be of type `StandardCard`. This works because `PackedScene` is now `PackedScene<T extends Node = Node>` and the generated contents of `standard-card.tscn.gen.d.ts` are as follows:

```ts
import StandardCard from "../../../src/example/standard-card";
declare module "godot" {
    interface ResourceTypes {
        "res://scenes/example/standard_card.tscn": PackedScene<StandardCard>;
    }
}
```

## Settings

As with scene node codegen, resource codegen can be disabled with editor settings:

![CleanShot 2025-04-04 at 01 10 10@2x](https://github.com/user-attachments/assets/e7ee02e6-86be-4930-b197-97f6ed8dc860)

## Customization

As with scene node codegen, users can customize the generated type for custom `Resource` by exporting a `codegen` function and handling the codegen request of type `CodeGenType.ScriptResourceTypeDescriptor` e.g.

```ts
export const codegen: CodeGenHandler = rawRequest => {
  const request = rawRequest.proxy();

  switch (request.type) {
    case CodeGenType.ScriptResourceTypeDescriptor: {
      return GDictionary.create<StringLiteralTypeDescriptor>({
        type: DescriptorType.StringLiteral,
        value: 'FooBar',
      });
    }
  }

  return undefined;
};
```
which would lead to the contents of `hmm.tres.gen.d.ts` becoming:
```ts
declare module "godot" {
    interface ResourceTypes {
        "res://scenes/example/hmm.tres": "FooBar";
    }
}
```
_**Note:** This is just for illustrative purposes. It's highly unlikely someone will implement a custom `Resource` that is somehow compliant with the string literal type `"FooBar"`!_
