### PR TITLE
fix: build against Godot 4.5dev2

### DIFF
--- a/bridge/jsb_editor_utility_funcs.cpp
+++ b/bridge/jsb_editor_utility_funcs.cpp
@@ -248,7 +248,7 @@ namespace jsb
             {
                 v8::Local<v8::Array> args_obj = v8::Array::New(isolate, argument_num);
                 int index = 0;
-                for (List<PropertyInfo>::ConstIterator it = method_info.arguments.begin(); it != method_info.arguments.end(); ++it)
+                for (auto it = method_info.arguments.begin(); it != method_info.arguments.end(); ++it)
                 {
                     jsb_check(index < argument_num);
                     const PropertyInfo& arg_info = *it;

--- a/internal/jsb_process.cpp
+++ b/internal/jsb_process.cpp
@@ -337,10 +337,11 @@ namespace jsb::internal
         {
             if (rd_line.is_empty()) return;
             String line;
-            if (line.append_utf8(rd_line.ptr()) == OK)
-            {
-               JSB_PROCESS_LOG(Log, "[%s] %s", proc_name, line);
-            }
+#if GODOT_4_5_OR_NEWER
+            if (line.append_utf8(rd_line.ptr()) == OK) JSB_PROCESS_LOG(Log, "[%s] %s", proc_name, line);
+#else
+            if (line.parse_utf8(rd_line.ptr()) == OK) JSB_PROCESS_LOG(Log, "[%s] %s", proc_name, line);
+#endif
             rd_line.clear();
         }
 

--- a/internal/jsb_process.cpp
+++ b/internal/jsb_process.cpp
@@ -337,7 +337,7 @@ namespace jsb::internal
         {
             if (rd_line.is_empty()) return;
             String line;
-            if (line.parse_utf8(rd_line.ptr()) == OK)
+            if (line.append_utf8(rd_line.ptr()) == OK)
             {
                JSB_PROCESS_LOG(Log, "[%s] %s", proc_name, line);
             }

--- a/weaver-editor/jsb_editor_plugin.cpp
+++ b/weaver-editor/jsb_editor_plugin.cpp
@@ -159,7 +159,7 @@ Error GodotJSEditorPlugin::apply_file(const jsb::weaver::InstallFileInfo &p_file
     if ((p_file.hint & jsb::weaver::CH_REPLACE_VARS) != 0)
     {
         String parsed;
-        parsed.parse_utf8(data, (int) size);
+        parsed.append_utf8(data, (int) size);
         parsed = parsed.replacen("__OUT_DIR__", jsb::internal::Settings::get_jsb_out_dir_name());
         parsed = parsed.replacen("__BUILD_INFO_FILE__", jsb::internal::Settings::get_tsbuildinfo_path());
         parsed = parsed.replacen("__SRC_DIR__", "../../../");  // locate typescripts at the project root path for better dev experience

--- a/weaver-editor/jsb_editor_plugin.cpp
+++ b/weaver-editor/jsb_editor_plugin.cpp
@@ -159,7 +159,11 @@ Error GodotJSEditorPlugin::apply_file(const jsb::weaver::InstallFileInfo &p_file
     if ((p_file.hint & jsb::weaver::CH_REPLACE_VARS) != 0)
     {
         String parsed;
+#if GODOT_4_5_OR_NEWER
         parsed.append_utf8(data, (int) size);
+#else
+        parsed.parse_utf8(data, (int) size);
+#endif
         parsed = parsed.replacen("__OUT_DIR__", jsb::internal::Settings::get_jsb_out_dir_name());
         parsed = parsed.replacen("__BUILD_INFO_FILE__", jsb::internal::Settings::get_tsbuildinfo_path());
         parsed = parsed.replacen("__SRC_DIR__", "../../../");  // locate typescripts at the project root path for better dev experience


### PR DESCRIPTION
Made changes to get this working with Godot `4.5dev2`.

We probably want to wait until 4.5 is released to actually merge this, because the string `parse -> append` changes are not backwards compatible with Godot 4.4. I'll make it a draft PR so we don't accidentally merge it.