### PR TITLE
Camel case binding runtime fixes

### DIFF
--- a/bridge/jsb_amd_module_loader.cpp
+++ b/bridge/jsb_amd_module_loader.cpp
@@ -51,7 +51,16 @@ namespace jsb
         {
             const v8::Local<v8::Context> context = isolate->GetCurrentContext();
             const v8::Local<v8::Function> evaluator = evaluator_.Get(isolate);
-            if (evaluator->Call(context, v8::Undefined(isolate), len, dep_vals).IsEmpty())
+            v8::Local<v8::Value> result;
+
+            if (evaluator->Call(context, v8::Undefined(isolate), len, dep_vals).ToLocal(&result))
+            {
+                if (!result->IsUndefined())
+                {
+                    p_module.exports.Reset(isolate, result);
+                }
+            }
+            else
             {
                 JSB_LOG(Error, "failed to evaluate AMD module");
                 succeeded = false;
@@ -73,6 +82,11 @@ namespace jsb
         jsb_check(len == (size_t)(int) len);
         _load_source(p_env, str, (int) len, p_source.get_filename());
         return OK;
+    }
+
+    void AMDModuleLoader::load_source(Environment* p_env, const String& p_source, const String& p_name)
+    {
+        _load_source(p_env, (const char*) p_source.ptr(), p_source.length(), p_name);
     }
 
     void AMDModuleLoader::_load_source(Environment* p_env, const char* p_source, int p_len, const String& p_name)

--- a/bridge/jsb_amd_module_loader.h
+++ b/bridge/jsb_amd_module_loader.h
@@ -13,6 +13,7 @@ namespace jsb
     private:
         Vector<String> deps_;
         v8::Global<v8::Function> evaluator_;
+        bool internal_;
 
     public:
         AMDModuleLoader(const Vector<String>& p_deps, v8::Global<v8::Function>&& p_evaluator)
@@ -23,11 +24,16 @@ namespace jsb
 
         virtual bool load(Environment* p_env, JavaScriptModule& p_module) override;
 
+        void set_internal(bool internal)
+        {
+            internal_ = internal;
+        }
+
         static Error load_source(Environment* p_env, const internal::PresetSource& p_source);
         static void load_source(Environment* p_env, const String& p_source, const String& p_name);
 
     private:
-        static void _load_source(Environment* p_env, const char* p_source, int p_len, const String& p_name);
+        static void _load_source(Environment* p_env, const char* p_source, int p_len, const String& p_name, bool p_internal = false);
     };
 
 }

--- a/bridge/jsb_amd_module_loader.h
+++ b/bridge/jsb_amd_module_loader.h
@@ -24,6 +24,7 @@ namespace jsb
         virtual bool load(Environment* p_env, JavaScriptModule& p_module) override;
 
         static Error load_source(Environment* p_env, const internal::PresetSource& p_source);
+        static void load_source(Environment* p_env, const String& p_source, const String& p_name);
 
     private:
         static void _load_source(Environment* p_env, const char* p_source, int p_len, const String& p_name);

--- a/bridge/jsb_builtins.cpp
+++ b/bridge/jsb_builtins.cpp
@@ -47,8 +47,13 @@ namespace jsb
             deps.push_back(item_str);
         }
         JSB_LOG(VeryVerbose, "new AMD module loader %s deps: %s", module_id_str, String(", ").join(deps));
-        env->add_module_loader<AMDModuleLoader>(module_id_str,
+        AMDModuleLoader& loader = env->add_module_loader<AMDModuleLoader>(module_id_str,
             deps, v8::Global<v8::Function>(isolate, info[2].As<v8::Function>()));
+
+        if (info.Data()->IsBoolean())
+        {
+            loader.set_internal(info.Data()->BooleanValue(isolate));
+        }
     }
 
     void Builtins::_require(const v8::FunctionCallbackInfo<v8::Value>& info)

--- a/bridge/jsb_editor_utility_funcs.cpp
+++ b/bridge/jsb_editor_utility_funcs.cpp
@@ -718,7 +718,8 @@ namespace jsb
                 {
                     JSB_HANDLE_SCOPE(isolate);
                     v8::Local<v8::Object> constant_obj = v8::Object::New(isolate);
-                    constants_obj->Set(context, impl::Helper::new_string(isolate, constant_doc.name), constant_obj).Check();
+                    String constant_name = internal::NamingUtil::get_constant_name(constant_doc.name);
+                    constants_obj->Set(context, impl::Helper::new_string(isolate, constant_name), constant_obj).Check();
 
                     set_field(isolate, context, constant_obj, "description", constant_doc.description);
                 }
@@ -734,7 +735,8 @@ namespace jsb
                 {
                     JSB_HANDLE_SCOPE(isolate);
                     v8::Local<v8::Object> method_obj = v8::Object::New(isolate);
-                    methods_obj->Set(context, impl::Helper::new_string(isolate, method_doc.name), method_obj).Check();
+                    String method_name = internal::NamingUtil::get_member_name(method_doc.name);
+                    methods_obj->Set(context, impl::Helper::new_string(isolate, method_name), method_obj).Check();
 
                     set_field(isolate, context, method_obj, "description", method_doc.description);
                 }
@@ -749,7 +751,8 @@ namespace jsb
                 {
                     JSB_HANDLE_SCOPE(isolate);
                     v8::Local<v8::Object> property_obj = v8::Object::New(isolate);
-                    properties_obj->Set(context, impl::Helper::new_string(isolate, property_doc.name), property_obj).Check();
+                    String property_name = internal::NamingUtil::get_member_name(property_doc.name);
+                    properties_obj->Set(context, impl::Helper::new_string(isolate, property_name), property_obj).Check();
 
                     set_field(isolate, context, property_obj, "description", property_doc.description);
                 }
@@ -765,7 +768,8 @@ namespace jsb
                 {
                     JSB_HANDLE_SCOPE(isolate);
                     v8::Local<v8::Object> signal_obj = v8::Object::New(isolate);
-                    signals_obj->Set(context, impl::Helper::new_string(isolate, signal_doc.name), signal_obj).Check();
+                    String signal_name = internal::NamingUtil::get_member_name(signal_doc.name);
+                    signals_obj->Set(context, impl::Helper::new_string(isolate, signal_name), signal_obj).Check();
 
                     set_field(isolate, context, signal_obj, "description", signal_doc.description);
                 }

--- a/bridge/jsb_environment.cpp
+++ b/bridge/jsb_environment.cpp
@@ -1273,19 +1273,22 @@ namespace jsb
         }
     }
 
-    v8::Local<v8::Function> Environment::_new_require_func(const String &p_module_id)
+    v8::Local<v8::Function> Environment::_new_require_func(const String &p_module_id, bool p_expose_main)
     {
         const v8::Local<v8::Context> context = context_.Get(isolate_);
         const v8::Local<v8::String> module_id = impl::Helper::new_string(isolate_, p_module_id);
         const v8::Local<v8::Function> require = JSB_NEW_FUNCTION(context, Builtins::_require, /* magic: module_id */ module_id);
-        if (v8::Local<v8::Object> main_module; _get_main_module(&main_module))
+        if (p_expose_main)
         {
-            require->Set(context, jsb_name(this, main), main_module).Check();
-        }
-        else
-        {
-            JSB_LOG(Log, "%s: require.main is not set due to main module not available", p_module_id);
-            require->Set(context, jsb_name(this, main), v8::Undefined(isolate_)).Check();
+            if (v8::Local<v8::Object> main_module; _get_main_module(&main_module))
+            {
+                require->Set(context, jsb_name(this, main), main_module).Check();
+            }
+            else
+            {
+                JSB_LOG(Log, "%s: require.main is not set due to main module not available", p_module_id);
+                require->Set(context, jsb_name(this, main), v8::Undefined(isolate_)).Check();
+            }
         }
         require->Set(context, jsb_name(this, cache), module_cache_.get_cache(isolate_)).Check();
         return require;

--- a/bridge/jsb_environment.cpp
+++ b/bridge/jsb_environment.cpp
@@ -314,6 +314,7 @@ namespace jsb
             internal::StringNames& names = internal::StringNames::get_singleton();
 
             // Populate StringNames replacement list so that classes can be lazily loaded by their exposed class name.
+            if (internal::Settings::get_camel_case_bindings_enabled())
             {
                 List<StringName> exposed_class_list = internal::NamingUtil::get_exposed_class_list();
 

--- a/bridge/jsb_environment.h
+++ b/bridge/jsb_environment.h
@@ -338,7 +338,7 @@ namespace jsb
 
         void rebind(Object* p_this, ScriptClassID p_class_id);
 
-        v8::Local<v8::Function> _new_require_func(const String& p_module_id);
+        v8::Local<v8::Function> _new_require_func(const String& p_module_id, bool p_expose_main = true);
 
         bool _get_main_module(v8::Local<v8::Object>* r_main_module) const;
 

--- a/bridge/jsb_environment.h
+++ b/bridge/jsb_environment.h
@@ -536,7 +536,7 @@ namespace jsb
         }
 
         // [unsafe, lowlevel, experimental] call a tweak function on the class
-        void on_class_post_bind(const NativeClassInfoPtr& p_class_info);
+        void on_class_post_bind(const NativeClassInfo* p_class_info);
 
         // [unsafe]
         // It's dangerous to hold the `NativeClassInfo` reference/pointer because the address is not ensured stable.

--- a/bridge/jsb_environment.h
+++ b/bridge/jsb_environment.h
@@ -542,7 +542,7 @@ namespace jsb
         }
 
         // [unsafe, lowlevel, experimental] call a tweak function on the class
-        void on_class_post_bind(const NativeClassInfo* p_class_info);
+        void on_class_post_bind(const StringName& p_class_name, const v8::Local<v8::Function>& p_class);
 
         // [unsafe]
         // It's dangerous to hold the `NativeClassInfo` reference/pointer because the address is not ensured stable.

--- a/bridge/jsb_environment.h
+++ b/bridge/jsb_environment.h
@@ -47,6 +47,12 @@ namespace jsb
 
             CrossBind,               // a symbol can only be used from C++ to indicate calling from cross-bind
             CDO,                     // constructing class default object for a script
+
+            // Exposed as properties on the `godot` module
+            FloatType,
+            IntegerType,
+            ProxyTarget,
+
             kNum,
         };
     }

--- a/bridge/jsb_godot_module_loader.cpp
+++ b/bridge/jsb_godot_module_loader.cpp
@@ -103,7 +103,7 @@ namespace jsb
             // dynamic binding: godot class types
             if (const NativeClassInfoPtr class_info = env->expose_godot_object_class(ClassDB::classes.getptr(original_name)))
             {
-                jsb_check(class_info->name == original_name);
+                jsb_check(class_info->name == p_type_name);
                 jsb_check(!class_info->clazz.IsEmpty());
                 info.GetReturnValue().Set(class_info->clazz.Get(isolate));
                 return;
@@ -140,8 +140,9 @@ namespace jsb
     {
         if (!loader_.IsEmpty()) return loader_.Get(p_env->get_isolate());
         const v8::Local<v8::Context> context = p_env->get_context();
-        const JavaScriptModule& typeloader = *p_env->get_module_cache().find(jsb_string_name(godot_typeloader));
-        const v8::Local<v8::Value> typeloader_exports = typeloader.exports.Get(p_env->get_isolate());
+        const JavaScriptModule* typeloader = p_env->get_module_cache().find(jsb_string_name(godot_typeloader));
+        jsb_check(typeloader != nullptr);
+        const v8::Local<v8::Value> typeloader_exports = typeloader->exports.Get(p_env->get_isolate());
         jsb_check(!typeloader_exports.IsEmpty() && typeloader_exports->IsObject());
         // not using string cache, as it's run only once
         const v8::Local<v8::Value> proxy_func_val = typeloader_exports.As<v8::Object>()->Get(context, impl::Helper::new_string_ascii(p_env->get_isolate(), "_mod_proxy_")).ToLocalChecked();

--- a/bridge/jsb_godot_module_loader.cpp
+++ b/bridge/jsb_godot_module_loader.cpp
@@ -37,18 +37,20 @@ namespace jsb
         // (1) singletons have the top priority (in GDScriptLanguage::init, singletons will overwrite the globals slot even if a type/const has the same name)
         //     check before getting to avoid error prints in `get_singleton_object`
         if (Engine::get_singleton()->has_singleton(original_name))
-        if (Object* gd_singleton = Engine::get_singleton()->get_singleton_object(original_name))
         {
-            JSB_LOG(VeryVerbose, "exposing singleton object %s", (String) original_name);
-            if (v8::Local<v8::Object> rval;
-                TypeConvert::gd_obj_to_js(isolate, context, gd_singleton, rval) && !rval.IsEmpty())
+            if (Object* gd_singleton = Engine::get_singleton()->get_singleton_object(original_name))
             {
-                env->mark_as_persistent_object(gd_singleton);
-                info.GetReturnValue().Set(rval);
+                JSB_LOG(VeryVerbose, "exposing singleton object %s", (String) original_name);
+                if (v8::Local<v8::Object> rval;
+                    TypeConvert::gd_obj_to_js(isolate, context, gd_singleton, rval) && !rval.IsEmpty())
+                {
+                    env->mark_as_persistent_object(gd_singleton);
+                    info.GetReturnValue().Set(rval);
+                    return;
+                }
+                jsb_throw(isolate, "failed to bind a singleton object");
                 return;
             }
-            jsb_throw(isolate, "failed to bind a singleton object");
-            return;
         }
 
         // (2) (global) utility functions.

--- a/bridge/jsb_godot_module_loader.cpp
+++ b/bridge/jsb_godot_module_loader.cpp
@@ -152,7 +152,11 @@ namespace jsb
         const v8::Local<v8::Function> proxy_func = proxy_func_val.As<v8::Function>();
         {
             v8::Isolate* isolate = p_env->get_isolate();
-            v8::Local<v8::Value> argv[] = { JSB_NEW_FUNCTION(context, _load_godot_object_class, {}) };
+            v8::Local<v8::Object> builtin_symbols = v8::Object::New(isolate);
+            builtin_symbols->Set(context, impl::Helper::new_string_ascii(isolate, "FloatType"), p_env->get_symbol(Symbols::FloatType));
+            builtin_symbols->Set(context, impl::Helper::new_string_ascii(isolate, "IntegerType"), p_env->get_symbol(Symbols::IntegerType));
+            builtin_symbols->Set(context, impl::Helper::new_string_ascii(isolate, "ProxyTarget"), p_env->get_symbol(Symbols::ProxyTarget));
+            v8::Local<v8::Value> argv[] = { builtin_symbols, JSB_NEW_FUNCTION(context, _load_godot_object_class, {}) };
             const v8::MaybeLocal<v8::Value> result = proxy_func->Call(context, v8::Undefined(isolate), std::size(argv), argv);
 
             if (v8::Local<v8::Value> proxy; result.ToLocal(&proxy))

--- a/bridge/jsb_object_bindings.cpp
+++ b/bridge/jsb_object_bindings.cpp
@@ -92,8 +92,8 @@ namespace jsb
              for (const KeyValue<StringName, MethodInfo>& pair : p_class_info->signal_map)
              {
                  v8::HandleScope handle_scope_for_signal(isolate);
-                 const StringName& signal_name = internal::NamingUtil::get_member_name(pair.key);
-                 const v8::Local<v8::String> signal_name_js = p_env->get_string_name_cache().get_string_value(isolate, signal_name);
+                 String signal_name = internal::NamingUtil::get_member_name(pair.key);
+                 const v8::Local<v8::String> signal_name_js = p_env->get_string_name_cache().get_string_value(isolate, pair.key);
                  class_builder.Instance().Property(signal_name, _godot_object_signal, signal_name_js.As<v8::Value>());
              }
 

--- a/bridge/jsb_type_convert.cpp
+++ b/bridge/jsb_type_convert.cpp
@@ -141,6 +141,12 @@ namespace jsb
     // translate js val into gd variant with an expected type
     bool TypeConvert::js_to_gd_var(v8::Isolate* isolate, const v8::Local<v8::Context>& context, const v8::Local<v8::Value>& p_jval, Variant::Type p_type, Variant& r_cvar)
     {
+        if (p_jval->IsProxy())
+        {
+            v8::Local<v8::Proxy> proxy = v8::Local<v8::Proxy>::Cast(p_jval);
+            return js_to_gd_var(isolate, context, proxy->GetTarget(), p_type, r_cvar);
+        }
+
         switch (p_type)
         {
         case Variant::FLOAT:
@@ -471,6 +477,11 @@ namespace jsb
         // if (p_jval->IsFunction())
         // {
         // }
+        if (p_jval->IsProxy())
+        {
+            const v8::Local<v8::Proxy> proxy = p_jval.As<v8::Proxy>();
+            return js_to_gd_var(isolate, context, proxy->GetTarget(), r_cvar);
+        }
         if (p_jval->IsObject())
         {
             const v8::Local<v8::Object> self = p_jval.As<v8::Object>();

--- a/internal/jsb_naming_util.cpp
+++ b/internal/jsb_naming_util.cpp
@@ -27,6 +27,7 @@ namespace jsb::internal
 			{ "Error", "GError" },
 			{ "Array", "GArray" },
 			{ "OpenXRIPBinding", "OpenXRIPBinding" },
+			{ "OpenXRIPBindingModifier", "OpenXRIPBindingModifier" },
 			{ "SkeletonModification2DCCDIK", "SkeletonModification2DCcdik" },
 			{ "SkeletonModification2DFABRIK", "SkeletonModification2DFabrik" },
 			{ "SkeletonModification3DCCDIK", "SkeletonModification3DCcdik" },
@@ -48,6 +49,7 @@ namespace jsb::internal
 			{ "IO", "IO" }, // Input/Output
 			{ "IP", "IP" }, // Internet Protocol
 			{ "IV", "IV" }, // Initialization Vector
+			{ "JS", "JS" }, // JavaScript
 			{ "MACOS", "MacOS" },
 			{ "NODEPATH", "NodePath" },
 			{ "SPIRV", "SpirV" },
@@ -273,13 +275,18 @@ namespace jsb::internal
 	List<StringName> NamingUtil::get_exposed_class_list()
 	{
 #ifdef TOOLS_ENABLED
-		const PackedStringArray ignored_classes = internal::Settings::get_ignored_classes();
-		const int ignored_classes_num = (int) ignored_classes.size();
-		HashSet<StringName> ignored_classes_set(ignored_classes_num);
+		HashSet<StringName> ignored_classes_set;
 
-		for (int i = 0; i < ignored_classes_num; ++i)
+		if (internal::Settings::editor_settings_available())
 		{
-			ignored_classes_set.insert(ignored_classes[i]);
+			const PackedStringArray ignored_classes = internal::Settings::get_ignored_classes();
+			const int ignored_classes_num = (int) ignored_classes.size();
+			ignored_classes_set.reserve(ignored_classes_num);
+
+			for (int i = 0; i < ignored_classes_num; ++i)
+			{
+				ignored_classes_set.insert(ignored_classes[i]);
+			}
 		}
 #endif
 
@@ -293,7 +300,7 @@ namespace jsb::internal
 			StringName class_name = *it;
 
 #ifdef TOOLS_ENABLED
-			if (ignored_classes_set.has(class_name))
+			if (ignored_classes_set.has(get_class_name(class_name)))
 			{
 				JSB_LOG(Verbose, "Ignoring class '%s' because it's in the ignored classes list", class_name);
 				continue;

--- a/internal/jsb_settings.cpp
+++ b/internal/jsb_settings.cpp
@@ -106,6 +106,11 @@ namespace jsb::internal
     }
 
 #ifdef TOOLS_ENABLED
+    bool Settings::editor_settings_available()
+    {
+        return EditorSettings::get_singleton() != nullptr || Engine::get_singleton()->is_editor_hint() || Engine::get_singleton()->is_project_manager_hint() || jsb_ext_is_cmdline_tool();
+    }
+
     PackedStringArray Settings::get_ignored_classes()
     {
         init_editor_settings();

--- a/internal/jsb_settings.h
+++ b/internal/jsb_settings.h
@@ -43,6 +43,7 @@ namespace jsb::internal
 
 #ifdef TOOLS_ENABLED
         // [EDITOR ONLY]
+        static bool editor_settings_available();
         static PackedStringArray get_ignored_classes();
         static bool get_autogen_scene_dts_on_save();
         static bool get_gen_scene_dts();

--- a/scripts/jsb.editor/src/jsb.editor.codegen.ts
+++ b/scripts/jsb.editor/src/jsb.editor.codegen.ts
@@ -256,7 +256,7 @@ const TypeMutations: Record<string, TypeMutation> = {
         property_overrides: {
             load: [
                 `static load<Path extends keyof ResourceTypes>(path: Path, ${names.get_parameter("type_hint")}?: string /* = "" */, ${names.get_parameter("cache_mode")}?: ResourceLoader.CacheMode /* = 1 */): ResourceTypes[Path]`,
-                "static load(path: string): Resource",
+                `static load(path: string, ${names.get_parameter("type_hint")}?: string /* = "" */, ${names.get_parameter("cache_mode")}?: ResourceLoader.CacheMode /* = 1 */): Resource`,
             ],
             load_threaded_get: [
                 `static load_threaded_get<Path extends keyof ResourceTypes>(path: Path): ResourceTypes[Path]`,

--- a/scripts/jsb.editor/tsconfig.json
+++ b/scripts/jsb.editor/tsconfig.json
@@ -26,7 +26,7 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "AMD",                                /* Specify what module code is generated. */
+    "module": "AMD",                                     /* Specify what module code is generated. */
     "rootDir": "./src",                                  /* Specify the root folder within your source files. */
     //"moduleResolution": "node10",                      /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */

--- a/scripts/jsb.runtime/src/godot.annotations.ts
+++ b/scripts/jsb.runtime/src/godot.annotations.ts
@@ -1,25 +1,7 @@
+import type * as Godot from "godot";
+import type * as GodotJsb from "godot-jsb";
 
-import { PropertyHint, PropertyUsageFlags, Variant, MultiplayerAPI, MultiplayerPeer } from "godot";
-import * as jsb from "godot-jsb";
-
-type UpperSnakeToPascalCase<S extends string> =
-	S extends `${infer T}_${infer U}`
-		? `${Capitalize<Lowercase<T>>}${UpperSnakeToPascalCase<Capitalize<Lowercase<U>>>}`
-		: Capitalize<Lowercase<S>>;
-
-function upperSnakeToPascalCase<T extends string>(input: T): UpperSnakeToPascalCase<T> {
-	return input
-		.toLowerCase()
-		.split('_')
-		.map(word => word.charAt(0).toUpperCase() + word.slice(1))
-		.join('') as UpperSnakeToPascalCase<T>;
-}
-
-// Godot's runtime can be toggled between snake case and camel case naming schemes. The types we're building against
-// use snake case, but if the user has camel case enabled, use of snake case would fail at runtime. We just try both.
-function enum_value<E, N extends keyof E & string>(enum_map: E, name: N): E[N] {
-	return (enum_map[name as keyof E] ?? enum_map[upperSnakeToPascalCase(name) as any as keyof E]) as E[N];
-}
+const { jsb, FloatType, IntegerType, Node, PropertyHint, PropertyUsageFlags, Resource, Variant } = require("godot.lib.api");
 
 function guess_type_name(type: any) {
     if (typeof type === "function") {
@@ -73,66 +55,66 @@ export function signal() {
 export const ExportSignal = signal;
 
 export function export_multiline() {
-    return export_(enum_value(Variant.Type, "TYPE_STRING"), { hint: enum_value(PropertyHint, "PROPERTY_HINT_MULTILINE_TEXT") });
+    return export_(Variant.Type.TYPE_STRING, { hint: PropertyHint.PROPERTY_HINT_MULTILINE_TEXT });
 }
 
 export const ExportMultiline = export_multiline;
 
-function __export_range(type: Variant.Type, min: number, max: number, step: number = 1, ...extra_hints: string[]) {
+function __export_range(type: Godot.Variant.Type, min: number, max: number, step: number = 1, ...extra_hints: string[]) {
     let hint_string = `${min},${max},${step}`;
     if (typeof extra_hints !== "undefined") {
         hint_string += "," + extra_hints.join(",");
     }
-    return export_(type, { hint: enum_value(PropertyHint, "PROPERTY_HINT_RANGE"), hint_string: hint_string });
+    return export_(type, { hint: PropertyHint.PROPERTY_HINT_RANGE, hint_string: hint_string });
 }
 
 export function export_range(min: number, max: number, step: number = 1, ...extra_hints: string[]) {
-    return __export_range(enum_value(Variant.Type, "TYPE_FLOAT"), min, max, step, ...extra_hints);
+    return __export_range(Variant.Type.TYPE_FLOAT, min, max, step, ...extra_hints);
 }
 
 export const ExportRange = export_range;
 
 export function export_range_i(min: number, max: number, step: number = 1, ...extra_hints: string[]) {
-    return __export_range(enum_value(Variant.Type, "TYPE_INT"), min, max, step, ...extra_hints);
+    return __export_range(Variant.Type.TYPE_INT, min, max, step, ...extra_hints);
 }
 
 export const ExportIntRange = export_range_i;
 
 /** String as a path to a file, custom filter provided as hint. */
 export function export_file(filter: string) {
-    return export_(enum_value(Variant.Type, "TYPE_STRING"), { hint: enum_value(PropertyHint, "PROPERTY_HINT_FILE"), hint_string: filter });
+    return export_(Variant.Type.TYPE_STRING, { hint: PropertyHint.PROPERTY_HINT_FILE, hint_string: filter });
 }
 
 export const ExportFile = export_file;
 
 export function export_dir(filter: string) {
-    return export_(enum_value(Variant.Type, "TYPE_STRING"), { hint: enum_value(PropertyHint, "PROPERTY_HINT_DIR"), hint_string: filter });
+    return export_(Variant.Type.TYPE_STRING, { hint: PropertyHint.PROPERTY_HINT_DIR, hint_string: filter });
 }
 
 export function export_global_file(filter: string) {
-    return export_(enum_value(Variant.Type, "TYPE_STRING"), { hint: enum_value(PropertyHint, "PROPERTY_HINT_GLOBAL_FILE"), hint_string: filter });
+    return export_(Variant.Type.TYPE_STRING, { hint: PropertyHint.PROPERTY_HINT_GLOBAL_FILE, hint_string: filter });
 }
 
 export const ExportGlobalFile = export_global_file;
 
 export function export_global_dir(filter: string) {
-    return export_(enum_value(Variant.Type, "TYPE_STRING"), { hint: enum_value(PropertyHint, "PROPERTY_HINT_GLOBAL_DIR"), hint_string: filter });
+    return export_(Variant.Type.TYPE_STRING, { hint: PropertyHint.PROPERTY_HINT_GLOBAL_DIR, hint_string: filter });
 }
 
 export const ExportGlobalDir = export_global_dir;
 
 export function export_exp_easing(hint?: "" | "attenuation" | "positive_only" | "attenuation,positive_only") {
-    return export_(enum_value(Variant.Type, "TYPE_FLOAT"), { hint: enum_value(PropertyHint, "PROPERTY_HINT_EXP_EASING"), hint_string: hint });
+    return export_(Variant.Type.TYPE_FLOAT, { hint: PropertyHint.PROPERTY_HINT_EXP_EASING, hint_string: hint });
 }
 
 // TODO: Godot's property hints make for a poor API. We should provide convenience methods to build them.
 export const ExportExpEasing = export_exp_easing;
 
 /**
- * A Shortcut for `export_(enum_value(Variant.Type, "TYPE_ARRAY"), { class_: clazz })`
+ * A Shortcut for `export_(Variant.Type.TYPE_ARRAY, { class_: clazz })`
  */
 export function export_array(clazz: ClassDescriptor) {
-    return export_(enum_value(Variant.Type, "TYPE_ARRAY"), { class_: clazz });
+    return export_(Variant.Type.TYPE_ARRAY, { class_: clazz });
 }
 
 export const ExportArray = export_array;
@@ -141,7 +123,7 @@ export const ExportArray = export_array;
  * A Shortcut for exporting a dictionary { class_: [key_class, value_class] })`
  */
 export function export_dictionary(key_class: ClassDescriptor, value_class: ClassDescriptor) {
-    return export_(enum_value(Variant.Type, "TYPE_DICTIONARY"), { class_: TypePair(key_class, value_class) });
+    return export_(Variant.Type.TYPE_DICTIONARY, { class_: TypePair(key_class, value_class) });
 }
 
 export const ExportDictionary = export_dictionary;
@@ -155,32 +137,31 @@ function get_hint_string_for_enum(enum_type: any): string {
 }
 
 function get_hint_string(clazz: any): string {
-    let gd = require("godot");
     if (typeof clazz === "symbol") {
-        if (clazz === gd.IntegerType) {
-            return enum_value(Variant.Type, "TYPE_INT") + ":";
+        if (clazz === IntegerType) {
+            return Variant.Type.TYPE_INT + ":";
         }
-        if (clazz === gd.FloatType) {
-            return enum_value(Variant.Type, "TYPE_FLOAT") + ":";
+        if (clazz === FloatType) {
+            return Variant.Type.TYPE_FLOAT + ":";
         }
     }
 
     if (typeof clazz === "function" && typeof clazz.prototype !== "undefined") {
-        if (clazz.prototype instanceof gd.Resource) {
-            return `${enum_value(Variant.Type, "TYPE_OBJECT")}/${enum_value(PropertyHint, "PROPERTY_HINT_RESOURCE_TYPE")}:${clazz.name}`;
-        } else if (clazz.prototype instanceof gd.Node) {
-            return `${enum_value(Variant.Type, "TYPE_OBJECT")}/${enum_value(PropertyHint, "PROPERTY_HINT_NODE_TYPE")}:${clazz.name}`;
+        if (clazz.prototype instanceof Resource) {
+            return `${Variant.Type.TYPE_OBJECT}/${PropertyHint.PROPERTY_HINT_RESOURCE_TYPE}:${clazz.name}`;
+        } else if (clazz.prototype instanceof Node) {
+            return `${Variant.Type.TYPE_OBJECT}/${PropertyHint.PROPERTY_HINT_NODE_TYPE}:${clazz.name}`;
         } else {
             // other than Resource and Node, only primitive types and enum types are supported in gdscript
             //TODO but we barely know anything about the enum types and int/float/StringName/... in JS
 
             if (clazz === Boolean) {
-                return enum_value(Variant.Type, "TYPE_BOOL") + ":";
+                return Variant.Type.TYPE_BOOL + ":";
             } else if (clazz === Number) {
                 // we can only guess the type is float
-                return enum_value(Variant.Type, "TYPE_FLOAT") + ":";
+                return Variant.Type.TYPE_FLOAT + ":";
             } else if (clazz === String) {
-                return enum_value(Variant.Type, "TYPE_STRING") + ":";
+                return Variant.Type.TYPE_STRING + ":";
             } else {
                 if (typeof (<any>clazz).__builtin_type__ === "number") {
                     return (<any>clazz).__builtin_type__ + ":";
@@ -193,13 +174,13 @@ function get_hint_string(clazz: any): string {
 
     if (typeof clazz === "object") {
         if (clazz instanceof EnumPlaceholderImpl) {
-            return `${enum_value(Variant.Type, "TYPE_INT")}/${enum_value(Variant.Type, "TYPE_INT")}:${get_hint_string_for_enum(clazz.target)}`;
+            return `${Variant.Type.TYPE_INT}/${Variant.Type.TYPE_INT}:${get_hint_string_for_enum(clazz.target)}`;
         }
 
         // probably an Array (as key-value type descriptor for a Dictionary)
         if (clazz instanceof TypePairPlaceholderImpl) {
             // special case for dictionary, int is preferred for key type of a dictionary
-            const key_type = clazz.key === Number ? enum_value(Variant.Type, "TYPE_INT") + ":" : get_hint_string(clazz.key);
+            const key_type = clazz.key === Number ? Variant.Type.TYPE_INT + ":" : get_hint_string(clazz.key);
             const value_type = get_hint_string(clazz.value);
 
             if (key_type.length === 0 || value_type.length === 0) {
@@ -212,7 +193,7 @@ function get_hint_string(clazz: any): string {
 }
 
 export function export_object(class_: ClassDescriptor) {
-    return export_(enum_value(Variant.Type, "TYPE_OBJECT"), { class_: class_ });
+    return export_(Variant.Type.TYPE_OBJECT, { class_: class_ });
 }
 
 export const ExportObject = export_object;
@@ -220,9 +201,9 @@ export const ExportObject = export_object;
 /**
  * [low level export]
  */
-export function export_(type: Variant.Type, details?: { class_?: ClassDescriptor, hint?: PropertyHint, hint_string?: string, usage?: PropertyUsageFlags }) {
+export function export_(type: Godot.Variant.Type, details?: { class_?: ClassDescriptor, hint?: Godot.PropertyHint, hint_string?: string, usage?: Godot.PropertyUsageFlags }) {
     return function (target: any, key: string) {
-        let ebd = { name: key, type: type, hint: enum_value(PropertyHint, "PROPERTY_HINT_NONE"), hint_string: "", usage: enum_value(PropertyUsageFlags, "PROPERTY_USAGE_DEFAULT") };
+        let ebd = { name: key, type: type, hint: PropertyHint.PROPERTY_HINT_NONE, hint_string: "", usage: PropertyUsageFlags.PROPERTY_USAGE_DEFAULT };
 
         if (typeof details === "object") {
             if (typeof details.hint === "number") ebd.hint = details.hint;
@@ -233,18 +214,17 @@ export function export_(type: Variant.Type, details?: { class_?: ClassDescriptor
             try {
                 //TODO more general and unified way to handle all types
 
-                if (type === enum_value(Variant.Type, "TYPE_OBJECT")) {
+                if (type === Variant.Type.TYPE_OBJECT) {
                     const clazz = details.class_;
-                    const gd = require("godot");
                     if (typeof clazz === "function" && typeof clazz.prototype !== "undefined") {
-                        if (clazz.prototype instanceof gd.Resource) {
-                            ebd.hint = enum_value(PropertyHint, "PROPERTY_HINT_RESOURCE_TYPE");
+                        if (clazz.prototype instanceof Resource) {
+                            ebd.hint = PropertyHint.PROPERTY_HINT_RESOURCE_TYPE;
                             ebd.hint_string = clazz.name;
-                            ebd.usage |= enum_value(PropertyUsageFlags, "PROPERTY_USAGE_SCRIPT_VARIABLE");
-                        } else if (clazz.prototype instanceof gd.Node) {
-                            ebd.hint = enum_value(PropertyHint, "PROPERTY_HINT_NODE_TYPE");
+                            ebd.usage |= PropertyUsageFlags.PROPERTY_USAGE_SCRIPT_VARIABLE;
+                        } else if (clazz.prototype instanceof Node) {
+                            ebd.hint = PropertyHint.PROPERTY_HINT_NODE_TYPE;
                             ebd.hint_string = clazz.name;
-                            ebd.usage |= enum_value(PropertyUsageFlags, "PROPERTY_USAGE_SCRIPT_VARIABLE");
+                            ebd.usage |= PropertyUsageFlags.PROPERTY_USAGE_SCRIPT_VARIABLE;
                         }
                     }
 
@@ -253,12 +233,12 @@ export function export_(type: Variant.Type, details?: { class_?: ClassDescriptor
                 }
                 let hint_string = get_hint_string(details.class_);
                 if (hint_string.length > 0) {
-                    ebd.hint = enum_value(PropertyHint, "PROPERTY_HINT_TYPE_STRING");
+                    ebd.hint = PropertyHint.PROPERTY_HINT_TYPE_STRING;
                     ebd.hint_string = hint_string;
-                    ebd.usage |= enum_value(PropertyUsageFlags, "PROPERTY_USAGE_SCRIPT_VARIABLE");
+                    ebd.usage |= PropertyUsageFlags.PROPERTY_USAGE_SCRIPT_VARIABLE;
                 }
             } catch (e) {
-                if (ebd.hint === enum_value(PropertyHint, "PROPERTY_HINT_NONE")) {
+                if (ebd.hint === PropertyHint.PROPERTY_HINT_NONE) {
                     console.warn("the given parameters are not supported or not implemented (you need to give hint/hint_string/usage manually)",
                         `class:${guess_type_name(Object.getPrototypeOf(target))} prop:${key} type:${type} class_:${guess_type_name(details.class_)}`);
                 }
@@ -268,7 +248,7 @@ export function export_(type: Variant.Type, details?: { class_?: ClassDescriptor
     }
 }
 
-export function Export(type: Variant.Type, details?: { class?: ClassDescriptor, hint?: PropertyHint, hintString?: string, usage?: PropertyUsageFlags }) {
+export function Export(type: Godot.Variant.Type, details?: { class?: ClassDescriptor, hint?: Godot.PropertyHint, hintString?: string, usage?: Godot.PropertyUsageFlags }) {
 	const { hintString, class: cls, ...consistent } = details ?? {};
 
 	return export_(type, {
@@ -284,7 +264,7 @@ export function Export(type: Variant.Type, details?: { class?: ClassDescriptor, 
  * They will also be available for editing in the property editor.
  * Exporting is done by using the `@export_var` (or `@export_`) annotation.
  */
-export function export_var(type: Variant.Type, details?: { class_?: ClassDescriptor, hint?: PropertyHint, hint_string?: string, usage?: PropertyUsageFlags }) {
+export function export_var(type: Godot.Variant.Type, details?: { class_?: ClassDescriptor, hint?: Godot.PropertyHint, hint_string?: string, usage?: Godot.PropertyUsageFlags }) {
     return export_(type, details);
 }
 
@@ -296,7 +276,7 @@ export const ExportVar = export_var;
 export function export_enum(enum_type: any) {
     return function (target: any, key: string) {
         let hint_string = get_hint_string_for_enum(enum_type);
-        let ebd = { name: key, type: enum_value(Variant.Type, "TYPE_INT"), hint: enum_value(PropertyHint, "PROPERTY_HINT_ENUM"), hint_string: hint_string, usage: enum_value(PropertyUsageFlags, "PROPERTY_USAGE_DEFAULT") };
+        let ebd = { name: key, type: Variant.Type.TYPE_INT, hint: PropertyHint.PROPERTY_HINT_ENUM, hint_string: hint_string, usage: PropertyUsageFlags.PROPERTY_USAGE_DEFAULT };
         jsb.internal.add_script_property(target, ebd);
     }
 }
@@ -315,7 +295,7 @@ export function export_flags(enum_type: any) {
                 enum_vs.push(v + ":" + c);
             }
         }
-        let ebd = { name: key, type: enum_value(Variant.Type, "TYPE_INT"), hint: enum_value(PropertyHint, "PROPERTY_HINT_FLAGS"), hint_string: enum_vs.join(","), usage: enum_value(PropertyUsageFlags, "PROPERTY_USAGE_DEFAULT") };
+        let ebd = { name: key, type: Variant.Type.TYPE_INT, hint: PropertyHint.PROPERTY_HINT_FLAGS, hint_string: enum_vs.join(","), usage: PropertyUsageFlags.PROPERTY_USAGE_DEFAULT };
         jsb.internal.add_script_property(target, ebd);
     }
 }
@@ -323,9 +303,9 @@ export function export_flags(enum_type: any) {
 export const ExportFlags = export_flags;
 
 export interface RPCConfig {
-    mode?: MultiplayerAPI.RPCMode,
+    mode?: Godot.MultiplayerAPI.RPCMode,
     sync?: "call_remote" | "call_local",
-    transfer_mode?: MultiplayerPeer.TransferMode,
+    transfer_mode?: Godot.MultiplayerPeer.TransferMode,
     transfer_channel?: number,
 }
 
@@ -355,7 +335,7 @@ export const Rpc = rpc;
  * auto initialized on ready (before _ready called)
  * @param evaluator for now, only string is accepted
  */
-export function onready(evaluator: string | jsb.internal.OnReadyEvaluatorFunc) {
+export function onready(evaluator: string | GodotJsb.internal.OnReadyEvaluatorFunc) {
     return function (target: any, key: string) {
         let ebd = { name: key, evaluator: evaluator };
         jsb.internal.add_script_ready(target, ebd);

--- a/scripts/jsb.runtime/src/godot.lib.api.ts
+++ b/scripts/jsb.runtime/src/godot.lib.api.ts
@@ -1,0 +1,299 @@
+import type * as Godot from "godot";
+import type * as GodotJsb from "godot-jsb";
+
+const Proxied = Symbol("lib_api_proxied");
+
+const { get_class, get_enum, get_enum_value, get_internal_mapping, get_member } = require("godot-jsb").internal.names;
+
+function pascal_to_upper_snake_case(str: string) {
+    return str.replace(/[a-z][A-Z]|[0-9][A-Z][a-z]/g, (m) => `${m[0]}_${m.slice(1)}`).toUpperCase();
+}
+
+function bind(target: any, value: any) {
+    return typeof value === "function" ? value.bind(target) : value;
+}
+
+function is_basic_object(value: object) {
+    const proto = Object.getPrototypeOf(value);
+    return proto === Object.prototype || !proto;
+}
+
+function proxy_value(value: any) {
+    if (value == null) {
+        return value;
+    }
+
+    if (value[Proxied]) {
+        return value;
+    }
+
+    if (typeof value === "function") {
+        const proxied_function = function(this: any, ...args: any[]) {
+            return proxy_value(value.apply(this, args.map(proxy_value)));
+        };
+        proxied_function[Proxied] = true;
+        return proxied_function;
+    }
+
+    if (typeof value !== "object") {
+        return value;
+    }
+
+    if (Array.isArray(value)) {
+        return array_proxy(value);
+    }
+
+    return is_basic_object(value) ? object_proxy(value) : instance_proxy(value);
+}
+
+const object_handler = {
+    get(target, p, _receiver) {
+        if (p === Proxied) {
+            return true;
+        }
+
+        const value = Reflect.get(target, p);
+
+        if (typeof p !== "string") {
+            return value;
+        }
+
+        if (p[0]?.toUpperCase() === p[0]
+          && value
+          && typeof value === "object"
+          && !Array.isArray(target)
+          && is_basic_object(value)
+          && !Object.entries(value).find(([k, v]) => k[0].toUpperCase() !== k[0] || typeof v !== "number")) {
+            return enum_proxy(value);
+        }
+
+        return proxy_value(bind(target, value));
+    },
+} satisfies ProxyHandler<any>;
+
+
+function array_proxy<T>(arr: T): T {
+    return new Proxy(arr, object_handler);
+}
+
+function object_proxy<T>(obj: T): T {
+    return new Proxy(obj, object_handler);
+}
+
+const instance_handler = {
+    defineProperty() {
+        return false;
+    },
+    deleteProperty() {
+        return false;
+    },
+    get(target, p, _receiver) {
+        if (p === Proxied) {
+            return true;
+        }
+
+        if (typeof p !== "string") {
+            return Reflect.get(target, p);
+        }
+
+        return proxy_value(bind(target, Reflect.get(target, p !== "toString" ? get_member(p) : p)));
+    },
+    getOwnPropertyDescriptor(target, p) {
+        return Reflect.getOwnPropertyDescriptor(target, typeof p === "string" ? get_member(p) : p);
+    },
+    has(target, p) {
+        return Reflect.has(target, typeof p === "string" ? get_member(p) : p);
+    },
+    isExtensible() {
+        return false;
+    },
+    ownKeys(target) {
+        return Reflect.ownKeys(target).map(key => typeof key === "string" && get_internal_mapping(key) || key);
+    },
+    preventExtensions() {
+        return true;
+    },
+    set(target, p, new_value, _receiver) {
+        return Reflect.set(target, typeof p === "string" ? get_member(p) : p, new_value);
+    },
+    setPrototypeOf(_target) {
+        return false;
+    },
+} satisfies ProxyHandler<any>;
+
+function instance_proxy<T>(target_instance: T): T {
+    return new Proxy(target_instance, instance_handler);
+}
+
+function proxied_constructor(this: (...args: any[]) => any, ...args: any[]) {
+    return instance_proxy(this.apply(this, args));
+}
+
+const class_handler = {
+    ...instance_handler,
+    construct(target, args, _new_target) {
+        return instance_proxy(new target(...args));
+    },
+    get(target, p, _receiver) {
+        if (p === Proxied) {
+            return true;
+        }
+
+        if (typeof p !== "string") {
+            return Reflect.get(target, p);
+        }
+
+        if (p === "constructor") {
+            return proxied_constructor;
+        }
+
+        if (p[0]?.toUpperCase() !== p[0]) {
+            return proxy_value(bind(target, Reflect.get(target, get_member(p))));
+        }
+
+        if (p.toUpperCase() === p) {
+            return proxy_value(bind(target, Reflect.get(target, p)));
+        }
+
+        return enum_proxy(Reflect.get(target, get_enum(p)));
+    },
+} satisfies ProxyHandler<any>;
+
+function class_proxy<T>(target_class: T): T {
+    return new Proxy(target_class, class_handler);
+}
+
+const enum_handler = {
+    defineProperty() {
+        return false;
+    },
+    deleteProperty() {
+        return false;
+    },
+    get(target, p, _receiver) {
+        if (p === Proxied) {
+            return true;
+        }
+
+        if (typeof p !== "string") {
+            return Reflect.get(target, p);
+        }
+
+        return bind(target, Reflect.get(target, get_enum_value(p)));
+    },
+    getOwnPropertyDescriptor(target, p) {
+        return Reflect.getOwnPropertyDescriptor(target, typeof p === "string" ? get_enum_value(p) : p);
+    },
+    has(target, p) {
+        return Reflect.has(target, typeof p === "string" ? get_enum_value(p) : p);
+    },
+    isExtensible() {
+        return false;
+    },
+    ownKeys(target) {
+        return Reflect.ownKeys(target).map(key => typeof key === "string" ? pascal_to_upper_snake_case(key) : key);
+    },
+    preventExtensions() {
+        return true;
+    },
+    set() {
+        return false;
+    },
+    setPrototypeOf() {
+        return false;
+    },
+} satisfies ProxyHandler<any>;
+
+function enum_proxy<T>(target_enum: T): T {
+    if (typeof target_enum !== "object") {
+        return target_enum;
+    }
+
+    return new Proxy(target_enum, enum_handler);
+}
+
+const api_handler = (target: any) => ({
+    defineProperty() {
+        return false;
+    },
+    deleteProperty() {
+        return false;
+    },
+    get(_pseudo_target, p, _receiver) {
+        if (p === Proxied) {
+            return true;
+        }
+
+        if (p in _pseudo_target) {
+            return _pseudo_target[p];
+        }
+
+        if (typeof p !== "string") {
+            return Reflect.get(target, p);
+        }
+
+        if (p === "toString") {
+            return proxy_value(bind(target, Reflect.get(target, p)));
+        }
+
+        // Special case, see jsb_godot_module_loader.cpp
+        if (p === "Variant") {
+            return object_proxy(Reflect.get(target, p))
+        }
+
+        if (p[0]?.toUpperCase() !== p[0]) {
+            return proxy_value(bind(target, Reflect.get(target, get_member(p))));
+        }
+
+        const value = Reflect.get(target, get_class(p));
+
+        if (typeof value === "function") {
+            return class_proxy(value);
+        }
+
+        if (value == null || typeof value !== "object") {
+            return value;
+        }
+
+        return is_basic_object(value) ? enum_proxy(value) : instance_proxy(value);
+    },
+    getOwnPropertyDescriptor(_pseudo_target, p) {
+        if (p in _pseudo_target) {
+            return Reflect.getOwnPropertyDescriptor(_pseudo_target, p);
+        }
+
+        return Reflect.getOwnPropertyDescriptor(target, typeof p === "string" ? get_member(p) : p);
+    },
+    has(_pseudo_target, p) {
+        return Reflect.has(target, typeof p === "string" ? get_class(p) : p) || Reflect.has(_pseudo_target, p);
+    },
+    isExtensible() {
+        return false;
+    },
+    ownKeys(_pseudo_target) {
+        return Reflect.ownKeys(target)
+            .map(key => typeof key === "string" && get_internal_mapping(key) || key)
+            .concat(Reflect.ownKeys(_pseudo_target));
+    },
+    preventExtensions() {
+        return true;
+    },
+    set(_pseudo_target, p, new_value, _receiver) {
+        return Reflect.set(target, typeof p === "string" ? get_member(p) : p, new_value);
+    },
+    setPrototypeOf(_pseudo_target) {
+        return false;
+    },
+} satisfies ProxyHandler<any>);
+
+const godot_jsb = object_proxy(require("godot-jsb")) as typeof GodotJsb;
+const api = new Proxy({ jsb: godot_jsb }, api_handler(require("godot"))) as typeof Godot & { jsb: typeof GodotJsb };
+
+/**
+ * This is a starting point for writing GodotJS code that is camel-case binding agnostic at runtime.
+ *
+ * Library code must consume this API rather than "godot", and be built with camel case bindings disabled. This is to
+ * ensure that the library will function at runtime for all projects irrespective of whether they have camel-case
+ * bindings enabled.
+ */
+export = api;

--- a/scripts/jsb.runtime/src/godot.typeloader.ts
+++ b/scripts/jsb.runtime/src/godot.typeloader.ts
@@ -67,13 +67,8 @@ export function on_type_loaded(type_name: string | string[], callback: TypeLoade
     }
 }
 
-const jsb_builtin_extras: { [key: string]: any } = {
-    "IntegerType": Symbol("IntegerType"), 
-    "FloatType":   Symbol("FloatType"), 
-}
-
 // callback on a godot type loaded by jsb_godot_module_loader
-exports._mod_proxy_ = function (type_loader_func: (type_name: string) => any): any {
+exports._mod_proxy_ = function (builtin_symbols: { [key in string]?: symbol }, type_loader_func: (type_name: string) => any): any {
     return new Proxy(type_db, {
         set: function (target, prop_name, value) {
             if (typeof prop_name !== 'string') {
@@ -89,8 +84,8 @@ exports._mod_proxy_ = function (type_loader_func: (type_name: string) => any): a
             let o = target[prop_name];
             if (typeof o === 'undefined' && typeof prop_name === 'string') {
                 o = target[prop_name] =
-                    typeof jsb_builtin_extras[prop_name] !== "undefined"
-                        ? jsb_builtin_extras[prop_name]
+                    typeof builtin_symbols[prop_name] !== "undefined"
+                        ? builtin_symbols[prop_name]
                         : type_loader_func(prop_name);
             }
             return o;

--- a/scripts/jsb.runtime/src/godot.typeloader.ts
+++ b/scripts/jsb.runtime/src/godot.typeloader.ts
@@ -75,8 +75,7 @@ const jsb_builtin_extras: { [key: string]: any } = {
 // callback on a godot type loaded by jsb_godot_module_loader
 exports._mod_proxy_ = function (type_loader_func: (type_name: string) => any): any {
     return new Proxy(type_db, {
-        // @ts-ignore
-        set: function (target: any, prop_name, value) {
+        set: function (target, prop_name, value) {
             if (typeof prop_name !== 'string') {
                 throw new Error(`only string key is allowed`);
             }
@@ -84,6 +83,7 @@ exports._mod_proxy_ = function (type_loader_func: (type_name: string) => any): a
                 console.warn('overwriting existing value', prop_name);
             }
             target[prop_name] = value;
+            return true;
         },
         get: function (target: any , prop_name) {
             let o = target[prop_name];

--- a/scripts/jsb.runtime/src/jsb.core.ts
+++ b/scripts/jsb.runtime/src/jsb.core.ts
@@ -1,6 +1,7 @@
+import type * as Godot from "godot";
+import type * as GodotJsb from "godot-jsb";
 
-import { MultiplayerAPI, MultiplayerPeer, PropertyHint, PropertyUsageFlags, Variant } from "godot";
-import * as jsb from "godot-jsb";
+const { jsb } = require("godot.lib.api");
 
 // [WARNING] ALL IMPLEMENTATIONS BELOW ARE FOR BACKWARD COMPATIBILITY ONLY.
 // [WARNING] THEY EXIST TO TEMPORARILY SUPPORT OLD CODES THAT USE THESE FUNCTIONS.
@@ -13,7 +14,7 @@ import * as jsb from "godot-jsb";
 exports.$wait = function (signal: any) {
     return new Promise(resolve => {
         let fn: any = null;
-        fn = require("godot").Callable.create(function () {
+        fn = require("godot.lib.api").create(function () {
             signal.disconnect(fn);
             if (arguments.length == 0) {
                 resolve(undefined);
@@ -71,10 +72,12 @@ exports.signal = function() {
  * @deprecated [WARNING] This function is deprecated. Use the same function from `godot.annotations` instead.
  */
 exports.export_multiline = function () {
+    const { PropertyHint, Variant } = require("godot.lib.api");
     return exports.export_(Variant.Type.TYPE_STRING, { hint: PropertyHint.PROPERTY_HINT_MULTILINE_TEXT });
 }
 
-function __export_range(type: Variant.Type, min: number, max: number, step: number = 1, ...extra_hints: string[]) {
+function __export_range(type: Godot.Variant.Type, min: number, max: number, step: number = 1, ...extra_hints: string[]) {
+    const { PropertyHint } = require("godot.lib.api");
     let hint_string = `${min},${max},${step}`;
     if (typeof extra_hints !== "undefined") {
         hint_string += "," + extra_hints.join(",");
@@ -87,6 +90,7 @@ function __export_range(type: Variant.Type, min: number, max: number, step: numb
  * @deprecated [WARNING] This function is deprecated. Use the same function from `godot.annotations` instead.
  */
 exports.export_range = function (min: number, max: number, step: number = 1, ...extra_hints: string[]) {
+    const { Variant } = require("godot.lib.api");
     return __export_range(Variant.Type.TYPE_FLOAT, min, max, step, ...extra_hints);
 }
 
@@ -95,6 +99,7 @@ exports.export_range = function (min: number, max: number, step: number = 1, ...
  * @deprecated [WARNING] This function is deprecated. Use the same function from `godot.annotations` instead.
  */
 exports.export_range_i = function (min: number, max: number, step: number = 1, ...extra_hints: string[]) {
+    const { Variant } = require("godot.lib.api");
     return __export_range(Variant.Type.TYPE_INT, min, max, step, ...extra_hints);
 }
 
@@ -103,6 +108,7 @@ exports.export_range_i = function (min: number, max: number, step: number = 1, .
  * @deprecated [WARNING] This function is deprecated. Use the same function from `godot.annotations` instead.
  */
 exports.export_file = function (filter: string) {
+    const { PropertyHint, Variant } = require("godot.lib.api");
     return exports.export_(Variant.Type.TYPE_STRING, { hint: PropertyHint.PROPERTY_HINT_FILE, hint_string: filter });
 }
 
@@ -112,6 +118,7 @@ exports.export_file = function (filter: string) {
  * @deprecated [WARNING] This function is deprecated. Use the same function from `godot.annotations` instead.
  */
 exports.export_dir = function (filter: string) {
+    const { PropertyHint, Variant } = require("godot.lib.api");
     return exports.export_(Variant.Type.TYPE_STRING, { hint: PropertyHint.PROPERTY_HINT_DIR, hint_string: filter });
 }
 
@@ -121,6 +128,7 @@ exports.export_dir = function (filter: string) {
  * @deprecated [WARNING] This function is deprecated. Use the same function from `godot.annotations` instead.
  */
 exports.export_global_file = function (filter: string) {
+    const { PropertyHint, Variant } = require("godot.lib.api");
     return exports.export_(Variant.Type.TYPE_STRING, { hint: PropertyHint.PROPERTY_HINT_GLOBAL_FILE, hint_string: filter });
 }
 
@@ -130,6 +138,7 @@ exports.export_global_file = function (filter: string) {
  * @deprecated [WARNING] This function is deprecated. Use the same function from `godot.annotations` instead.
  */
 exports.export_global_dir = function (filter: string) {
+    const { PropertyHint, Variant } = require("godot.lib.api");
     return exports.export_(Variant.Type.TYPE_STRING, { hint: PropertyHint.PROPERTY_HINT_GLOBAL_DIR, hint_string: filter });
 }
 
@@ -139,6 +148,7 @@ exports.export_global_dir = function (filter: string) {
  * @deprecated [WARNING] This function is deprecated. Use the same function from `godot.annotations` instead.
  */
 exports.export_exp_easing = function (hint?: "" | "attenuation" | "positive_only" | "attenuation,positive_only") {
+    const { PropertyHint, Variant } = require("godot.lib.api");
     return exports.export_(Variant.Type.TYPE_FLOAT, { hint: PropertyHint.PROPERTY_HINT_EXP_EASING, hint_string: hint });
 }
 
@@ -147,7 +157,8 @@ exports.export_exp_easing = function (hint?: "" | "attenuation" | "positive_only
  * FOR BACKWARD COMPATIBILITY ONLY
  * @deprecated [WARNING] This function is deprecated. Use the same function from `godot.annotations` instead.
  */
-exports.export_ = function (type: Variant.Type, details?: { class_?: Function, hint?: PropertyHint, hint_string?: string, usage?: PropertyUsageFlags }) {
+exports.export_ = function (type: Godot.Variant.Type, details?: { class_?: Function, hint?: Godot.PropertyHint, hint_string?: string, usage?: Godot.PropertyUsageFlags }) {
+    const { PropertyHint, PropertyUsageFlags } = require("godot.lib.api");
     return function (target: any, key: string) {
         let ebd = { name: key, type: type, hint: PropertyHint.PROPERTY_HINT_NONE, hint_string: "", usage: PropertyUsageFlags.PROPERTY_USAGE_DEFAULT };
         if (typeof details === "object") {
@@ -164,6 +175,7 @@ exports.export_ = function (type: Variant.Type, details?: { class_?: Function, h
  * @deprecated [WARNING] This function is deprecated. Use the same function from `godot.annotations` instead.
  */
 exports.export_enum = function (enum_type: any) {
+    const { PropertyHint, PropertyUsageFlags, Variant } = require("godot.lib.api");
     return function (target: any, key: string) {
         let enum_vs: Array<string> = [];
         for (let c in enum_type) {
@@ -182,6 +194,7 @@ exports.export_enum = function (enum_type: any) {
  * @deprecated [WARNING] This function is deprecated. Use the same function from `godot.annotations` instead.
  */
 exports.export_flags = function (enum_type: any) {
+    const { PropertyHint, PropertyUsageFlags, Variant } = require("godot.lib.api");
     return function (target: any, key: string) {
         let enum_vs: Array<string> = [];
         for (let c in enum_type) {
@@ -196,9 +209,9 @@ exports.export_flags = function (enum_type: any) {
 }
 
 interface RPCConfig {
-    mode?: MultiplayerAPI.RPCMode,
+    mode?: Godot.MultiplayerAPI.RPCMode,
     sync?: "call_remote" | "call_local",
-    transfer_mode?: MultiplayerPeer.TransferMode,
+    transfer_mode?: Godot.MultiplayerPeer.TransferMode,
     transfer_channel?: number,
 }
 
@@ -207,7 +220,7 @@ interface RPCConfig {
  * @deprecated [WARNING] This function is deprecated. Use the same function from `godot.annotations` instead.
  */
 exports.rpc = function (config?: RPCConfig) {
-    return function (target: any, propertyKey?: PropertyKey, descriptor?: PropertyDescriptor) {
+    return function (target: any, propertyKey?: PropertyKey) {
         if (typeof propertyKey !== "string") {
             throw new Error("only string is allowed as propertyKey for rpc config");
             return;
@@ -230,7 +243,7 @@ exports.rpc = function (config?: RPCConfig) {
  * FOR BACKWARD COMPATIBILITY ONLY
  * @deprecated [WARNING] This function is deprecated. Use the same function from `godot.annotations` instead.
  */
-exports.onready = function (evaluator: string | jsb.internal.OnReadyEvaluatorFunc) {
+exports.onready = function (evaluator: string | GodotJsb.internal.OnReadyEvaluatorFunc) {
     return function (target: any, key: string) {
         let ebd = { name: key, evaluator: evaluator };
         jsb.internal.add_script_ready(target, ebd);
@@ -262,7 +275,7 @@ exports.icon = function (path: string) {
  * @deprecated [WARNING] This function is deprecated. Use the same function from `godot.annotations` instead.
  */
 exports.deprecated = function (message?: string) {
-    return function (target: any, propertyKey?: PropertyKey, descriptor?: PropertyDescriptor) {
+    return function (target: any, propertyKey?: PropertyKey) {
         if (typeof propertyKey === "undefined") {
             jsb.internal.set_script_doc(target, undefined, 0, message ?? "");
             return;
@@ -277,7 +290,7 @@ exports.deprecated = function (message?: string) {
  * @deprecated [WARNING] This function is deprecated. Use the same function from `godot.annotations` instead.
  */
 exports.experimental = function (message?: string) {
-    return function (target: any, propertyKey?: PropertyKey, descriptor?: PropertyDescriptor) {
+    return function (target: any, propertyKey?: PropertyKey) {
         if (typeof propertyKey === "undefined") {
             jsb.internal.set_script_doc(target, undefined, 1, message ?? "");
             return;
@@ -292,7 +305,7 @@ exports.experimental = function (message?: string) {
  * @deprecated [WARNING] This function is deprecated. Use the same function from `godot.annotations` instead.
  */
 exports.help = function (message?: string) {
-    return function (target: any, propertyKey?: PropertyKey, descriptor?: PropertyDescriptor) {
+    return function (target: any, propertyKey?: PropertyKey) {
         if (typeof propertyKey === "undefined") {
             jsb.internal.set_script_doc(target, undefined, 2, message ?? "");
             return;
@@ -307,7 +320,8 @@ exports.help = function (message?: string) {
  * @deprecated [WARNING] This function is deprecated. Use the same function from `godot` instead.
  */
 exports.GLOBAL_GET = function (entry_path: any): any {
-    return require("godot").ProjectSettings.get_setting_with_override(entry_path);
+    const { ProjectSettings } = require("godot.lib.api");
+    return ProjectSettings.get_setting_with_override(entry_path);
 }
 
 /**
@@ -315,5 +329,6 @@ exports.GLOBAL_GET = function (entry_path: any): any {
  * @deprecated [WARNING] This function is deprecated. Use the same function from `godot` instead.
  */
 exports.EDITOR_GET = function (entry_path: any): any {
-    return require("godot").EditorInterface.get_editor_settings().get(entry_path);
+    const { EditorInterface } = require("godot.lib.api");
+    return EditorInterface.get_editor_settings().get(entry_path);
 }

--- a/scripts/jsb.runtime/src/jsb.inject.ts
+++ b/scripts/jsb.runtime/src/jsb.inject.ts
@@ -2,22 +2,12 @@ import type * as Godot from "godot";
 import type * as GodotJsb from "godot-jsb";
 
 type GArrayProxy<T> = Godot.GArrayProxy<T> & {
-    [ProxyTarget]: Godot.GArray<T>;
+    [Godot.ProxyTarget]: Godot.GArray<T>;
 }
 
 type GDictionaryProxy<T> = Godot.GDictionaryProxy<T> & {
-    [ProxyTarget]: Godot.GDictionary<T>;
+    [Godot.ProxyTarget]: Godot.GDictionary<T>;
 };
-
-const ProxyTarget = Symbol("proxy_target");
-
-const proxy_unwrap = function(value: any) {
-    if (typeof value !== "object" || value === null) {
-        return value;
-    }
-
-    return value[ProxyTarget] ?? value;
-}
 
 const proxyable_prototypes: any[] = [];
 
@@ -33,6 +23,16 @@ const proxy_wrap = function(value: any) {
 };
 
 require("godot.typeloader").on_type_loaded("GArray", function (type: any) {
+    const ProxyTarget = require("godot").ProxyTarget;
+
+    const proxy_unwrap = function(value: any) {
+        if (typeof value !== "object" || value === null) {
+            return value;
+        }
+
+        return value[ProxyTarget] ?? value;
+    };
+
     const get_member = (require("godot-jsb") as typeof GodotJsb).internal.names.get_member;
 
     proxyable_prototypes.push(type.prototype);
@@ -193,6 +193,16 @@ require("godot.typeloader").on_type_loaded("GArray", function (type: any) {
 });
 
 require("godot.typeloader").on_type_loaded("GDictionary", function (type: any) {
+    const ProxyTarget = require("godot").ProxyTarget;
+
+    const proxy_unwrap = function(value: any) {
+        if (typeof value !== "object" || value === null) {
+            return value;
+        }
+
+        return value[ProxyTarget] ?? value;
+    };
+
     const get_member = (require("godot-jsb") as typeof GodotJsb).internal.names.get_member;
 
     proxyable_prototypes.push(type.prototype);

--- a/scripts/jsb.runtime/src/main.ts
+++ b/scripts/jsb.runtime/src/main.ts
@@ -1,0 +1,1 @@
+require("jsb.inject");

--- a/scripts/typings/godot.minimal.d.ts
+++ b/scripts/typings/godot.minimal.d.ts
@@ -5,7 +5,7 @@ declare module "godot-jsb" {
         MethodFlags,
         MultiplayerAPI,
         MultiplayerPeer,
-        Object as GDObject,
+        Object as GObject,
         PackedByteArray,
         PropertyInfo,
         StringName,
@@ -33,7 +33,7 @@ declare module "godot-jsb" {
      * Create godot Callable with a bound object `self`.
      * @deprecated [WARNING] avoid using this function directly, use `Callable.create` instead.
      */
-    function callable<S extends GDObject, F extends (this: S, ...args: any[]) => any>(self: S, fn: F): Callable<F>;
+    function callable<S extends GObject, F extends (this: S, ...args: any[]) => any>(self: S, fn: F): Callable<F>;
 
     /**
      * Explicitly convert a `PackedByteArray`(aka `Vector<uint8_t>`) into a javascript `ArrayBuffer`
@@ -108,19 +108,45 @@ declare module "godot-jsb" {
         function add_script_ready(target: any, details: { name: string, evaluator: string | OnReadyEvaluatorFunc }): void;
         function add_script_tool(target: any): void;
         function add_script_icon(target: any, path: string): void;
-        function add_script_rpc(target: any, propertyKey: string, config: RPCConfig): void;
+        function add_script_rpc(target: any, property_key: string, config: RPCConfig): void;
 
         // 0: deprecated, 1: experimental, 2: help
-        function set_script_doc(target: any, propertyKey: undefined | string, field: 0 | 1 | 2, message: string): void;
+        function set_script_doc(target: any, property_key: undefined | string, field: 0 | 1 | 2, message: string): void;
 
         function add_module(id: string, obj: any): void;
         function find_module(id: string): any;
         function notify_microtasks_run(): void;
 
-        /**
-         * Get the transformed type name of a Variant.Type
-         */
-        function get_type_name(type: Variant.Type): StringName;
+        namespace names {
+            /**
+             * Get the transformed name of a Godot class
+             */
+            function get_class<T extends string>(godot_class: T): T;
+            /**
+             * Get the transformed name of a Godot enum
+             */
+            function get_enum<T extends string>(godot_enum: T): T;
+            /**
+             * Get the transformed name of a Godot enum
+             */
+            function get_enum_value<T extends string>(godot_enum_value: T): T;
+            /**
+             * Get the transformed name of a Godot class member
+             */
+            function get_member<T extends string>(godot_member: T): T;
+            /**
+             * Get the internal Godot name/identifier from a transformed name i.e. the inverse of the other accessors.
+             */
+            function get_internal_mapping(name: string): string;
+            /**
+             * Get the transformed name of a Godot function parameter
+             */
+            function get_parameter<T extends string>(parameter: T): T;
+            /**
+             * Get the transformed type name of a Variant.Type
+             */
+            function get_variant_type<T extends string>(type: Variant.Type): StringName;
+        }
     }
 
     namespace editor {
@@ -275,4 +301,3 @@ declare module "godot-jsb" {
         const VERSION_DOCS_URL: string;
     }
 }
-

--- a/scripts/typings/godot.mix.d.ts
+++ b/scripts/typings/godot.mix.d.ts
@@ -31,7 +31,7 @@ declare module "godot" {
      * FOR BACKWARD COMPATIBILITY ONLY
      * @deprecated [WARNING] Use Callable<T>.
      */
-    type Callable2<T1, T2, R = void> = Callable<(v1: T1, v2, T2) => R>;
+    type Callable2<T1, T2, R = void> = Callable<(v1: T1, v2: T2) => R>;
 
     /**
      * FOR BACKWARD COMPATIBILITY ONLY
@@ -67,7 +67,7 @@ declare module "godot" {
      * FOR BACKWARD COMPATIBILITY ONLY
      * @deprecated [WARNING] Use Signal<T>.
      */
-    type Signal2<T1, T2> = Signal<(v1: T1, v2, T2) => void>;
+    type Signal2<T1, T2> = Signal<(v1: T1, v2: T2) => void>;
 
     /**
      * FOR BACKWARD COMPATIBILITY ONLY
@@ -204,7 +204,7 @@ declare module "godot" {
         usage: PropertyUsageFlags;
     }
 
-  type BindRight<F extends (this: any, ...args: any[]) => any, B extends any[]> =
+  type BindRight<F extends Function, B extends any[]> =
     F extends (this: infer T, ...args: [...(infer A), ...B]) => infer R
       ? (this: T, ...args: A) => R
       : never;

--- a/scripts/typings/godot.mix.d.ts
+++ b/scripts/typings/godot.mix.d.ts
@@ -2,6 +2,16 @@
 declare module "godot" {
     export const IntegerType: unique symbol;
     export const FloatType: unique symbol;
+    /**
+     * Proxy objects are typically transparent by design, allowing a proxy to impersonate a type. However, GodotJS also
+     * makes use of proxies to wrap existing objects in order to provide a more convenient API. In such cases, it is
+     * convenient to be able to unwrap the object i.e. obtain access to the target object. In order to achieve this,
+     * GodotJS exposes a property with the key ProxyTarget. You can access this to, for example, obtain direct access
+     * to the original GDictionary wrapped via a call to .proxy(). Additionally, GodotJS uses this property internally
+     * to unwrap proxies, thus allowing you to pass a proxy wrapped GArray/GDictionary as an argument to any function
+     * expecting a GArray/GDictionary parameter.
+     */
+    export const ProxyTarget: unique symbol;
 
     /**
      * FOR BACKWARD COMPATIBILITY ONLY

--- a/weaver-editor/jsb_editor_plugin.h
+++ b/weaver-editor/jsb_editor_plugin.h
@@ -67,6 +67,7 @@ protected:
     // Crash if the given info is invalid, ensure to update the preset list in C++ code after it changed in SCsub.
     void add_install_file(jsb::weaver::InstallFileInfo&& p_install_file);
 
+    static String mutate_types(const String& p_content);
     static Error apply_file(const jsb::weaver::InstallFileInfo& p_file);
     static bool install_files(const Vector<jsb::weaver::InstallFileInfo>& p_files);
     static Vector<jsb::weaver::InstallFileInfo> filter_files(const Vector<jsb::weaver::InstallFileInfo>& p_files, int p_hint);


### PR DESCRIPTION
There's a few commits here, but the common thread is fixing runtime bugs in the recently introduced camel-case bindings.

# godot.lib.api

This PR introduces a `godot.lib.api` module. This module allows you to write camel-case binding insensitive code.

The top-level export is a proxy wrapping the `godot` API. When you consume APIs (access properties or call methods), the resultant values are also wrapped in proxies. The purpose of these proxies are to (as seamlessly as possible) translate non-camel-case APIs to camel-case APIs _if_ the project has camel-case bindings enabled.

The primary purpose of the module is for GodotJS internals to consume this API. A benefit of this approach is that the codegen code for example is now much cleaner. It now much more closely resembles the original implementation prior to https://github.com/godotjs/GodotJS/pull/65 being merged i.e. the implementation for the most part no longer needs to concern itself with whether camel-case bindings are enabled, it's abstracted away. However, beyond cleaning up code, there were some bugs I'd missed with the use of flags e.g. `Object.ConnectFlags.CONNECT_ONE_SHOT`. This was coming through as undefined when camel-case bindings were enabled, because the correct property name when camel-case bindings are enabled is `Object.ConnectFlags.ConnectOneShot`. `godot.lib.api` now seamlessly translates `Object.ConnectFlags.CONNECT_ONE_SHOT` into `Object.ConnectFlags.ConnectOneShot`.

The proxies do of course introduce overhead, however it ought to be negligible for user code, since the proxies only come into play for `godot.lib.api`, there's no overhead when consuming `godot` as per normal. The main place where some overhead may have appeared is in the editor, say for example during codegen. Codegen does make fairly extensive use of `godot.lib.api`, because the codegen code needs to operate irrespective of the user's camel-case bindings setting.

Somewhat inadvertently, `godot.lib.api` is also useful if users wish to distribute libraries that are themselves camel-case binding agnostic. In their library it ought to be as simple as replacing an import of `godot` with `godot.lib.api` and their library will be safe to import in projects that have camel-case bindings enabled. 

# AMD module return value support

I've implemented support for AMD return values, whilst maintaining support for the `exports` dependency (CommonJS-style). This can be achieved in TypeScript by taking advantage of TypeScript's [`export =` syntax](https://www.typescriptlang.org/docs/handbook/modules/reference.html#export--and-import--require). This was necessary in order to export a proxy rather than an object from a module, not as the default value, but rather as the module export itself. This allows `godot.lib.api` to be a drop-in replacement for `godot`.

# jsb.runtime entry-point is now main.ts

`jsb.inject.ts` was the previous entry-point.

When generating an AMD bundle, the TypeScript compiler bundles all ES6/ESM modules by wrapping them in AMD's `define()`. Any TS files which are not ES modules are included directly in the bundle (side effects executed on load). Consequently `jsb.inject.ts`, which was previously the entry-point was not implemented as an ES module, it used `require` syntax exclusively. However, this meant that the implementation was not able to import any types, since even the introduction of `import type` syntax (no runtime imports) caused tsc to treat the file as an ES module.

Thus, `jsb.inject.ts` was not type-safe. To make the implementation less error prone, I've added (imported) types into `jsb.inject.ts`. Which, as mentioned, caused tsc to treat this file as an ES module i.e. no longer an entry point. To rectify this, I've introduced `main.ts`, which is itself not an ES module, it simply requires `jsb.inject.ts`.

Related to this, [the final commit](https://github.com/godotjs/GodotJS/pull/74/commits/a06e2c0a3f5536d302b329db7ef5d5649fde225b) in this PR is a largely non-functional change. The AMD module loader has logic to set `require.main`, and complained (logged) when it was unable to do so. Because we're now calling `require` on start-up of our runtime bundle, this logging was appearing on start-up. The final change-set simply ensures this logging doesn't take place, since it's expected `require.main` is unavailable at this point.

# [fix: TypeLoader _post_bind_ class loading](https://github.com/godotjs/GodotJS/pull/74/commits/59bb8d0ea10a6c2655500e234f2e0dbc6dddb972)

i.e. Fixed typeloader callbacks being unable to load types.

Previously, when calling into `_post_bind_` (user code) we had in scope a `NativeClassInfoPtr` (`internal::SArray<NativeClassInfo, NativeClassID>::Pointer`) which holds a lock on the environment's `native_classes_` array. This resulted in crash if the callback itself attempted to load another type.

# [fix: QuickJS support and fix SceneNode codegen.](https://github.com/godotjs/GodotJS/pull/74/commits/3179623506b4a435f0a5a1a4d5c3af3aeb6eeaef)

This commit is really a follow-up (fix-up commit) for the first commit in the series. Typically I squash these back into the original commit, but it includes a decent commit message which will make a `git blame` on these lines of code much more informative. So I decided to keep it separate.

It's worth noting that this commit moves the `[[FloatType]]` and `[[IntegerType]]` symbols from TypeScript into C++, now defined in the same location as all our other symbols. The motivation for this was that I've introduced a new symbol `[[ProxyTarget]]` which I wanted to access from both C++ and TypeScript. Rather than having 3 different ways in which symbols are defined, I've consolidated. Accessing the `[[ProxyTarget]]` property in C++ became necessary when I realised our `QuickJS` v8 interop layer doesn't implement `IsProxy()`, and `GetTarget()`, and that they're in fact impossible to implement (without changing QuickJS itself). Thus the `[[ProxyTarget]]` symbol is used in place of `GetTarget()`. 

# [fix: Native object signals not firing in camel-case bindings mode](https://github.com/godotjs/GodotJS/pull/74/commits/5073bc4fcc9ac6685a9eead258d751e6cd50b135)
The LRU StringName cache was implemented in parallel to camel-case bindings. It made changes to the way GodotJS' pseudo-`Signal`s operate. Essentially the JS property name was assumed to be the same as the Signal name in Godot/GDScript. However, with the introduction of camel-case bindings project setting, camel-case naming conventions are used for all properties, including signals. So when both camel-case bindings and the LRU cache landed together on main, signals stopped working for projects using camel-case API bindings.