### PR TITLE
fix: builds for macos by creating app

### DIFF
--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -122,3 +122,64 @@ jobs:
         uses: ./.github/actions/upload-artifact
         with:
           name: ${{ matrix.cache-name }}
+
+  build-macos-apps:
+    needs:
+      - build-macos
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        engine: [ v8,qjs-ng ]
+    steps:
+      - name: Checkout Godot
+        uses: actions/checkout@v4
+        with:
+          repository: godotengine/godot
+          ref: ${{ inputs.version }}
+          submodules: recursive
+
+      - name: ⏬ Download editor
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-editor-${{ matrix.engine }}
+          path: macos-editor-${{ matrix.engine }}
+
+      - name: ⚒️ Build Editor App
+        run: |
+          cp -r misc/dist/macos_tools.app Godot.app
+          mkdir -p Godot.app/Contents/MacOS
+          cp macos-editor-${{ matrix.engine }}/godot.macos.editor.universal Godot.app/Contents/MacOS/Godot
+          chmod +x Godot.app/Contents/MacOS/Godot
+
+      - name: ⏫ Upload editor app
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-editor-app-${{ matrix.engine }}
+          path: Godot.app
+
+      - name: ⏬ Download template-release
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-template-release-${{ matrix.engine }}
+          path: macos-template-release-${{ matrix.engine }}
+
+      - name: ⏬ Download template-debug
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-template-debug-${{ matrix.engine }}
+          path: macos-template-debug-${{ matrix.engine }}
+
+      - name: ⚒️ Build Template App
+        run: |
+          cp -r misc/dist/macos_template.app .
+          mkdir -p macos_template.app/Contents/MacOS
+          cp macos-template-release-${{ matrix.engine }}/godot.macos.template_release.universal macos_template.app/Contents/MacOS/godot_macos_release.universal
+          cp macos-template-debug-${{ matrix.engine }}/godot.macos.template_debug.universal macos_template.app/Contents/MacOS/godot_macos_debug.universal
+          chmod +x macos_template.app/Contents/MacOS/godot_macos*
+
+      - name: ⏫ Upload template app
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-template-app-${{ matrix.engine }}
+          path: macos_template.app

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -153,7 +153,7 @@ jobs:
           chmod +x Godot.app/Contents/MacOS/Godot
 
       - name: ⏫ Upload editor app
-        uses: actions/download-artifact@v4
+        uses: actions/upload-artifact@v4
         with:
           name: macos-editor-app-${{ matrix.engine }}
           path: Godot.app
@@ -179,7 +179,7 @@ jobs:
           chmod +x macos_template.app/Contents/MacOS/godot_macos*
 
       - name: ⏫ Upload template app
-        uses: actions/download-artifact@v4
+        uses: actions/upload-artifact@v4
         with:
           name: macos-template-app-${{ matrix.engine }}
           path: macos_template.app

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -111,6 +111,11 @@ jobs:
           cache-name: ${{ matrix.cache-name }}
         continue-on-error: true
 
+# TODO: The x86_64 build isn't working with `Forward+` projects see: https://github.com/godotengine/godot/issues/64471
+# Check why the official build is working:
+# - https://github.com/godotengine/godot-build-scripts/blob/main/build.sh#L147-L157
+# - https://github.com/godotengine/godot-build-scripts/blob/main/build-macos/build.sh#L7-L87
+# - https://github.com/godotengine/godot-build-scripts/blob/main/build-release.sh#L367-L375
       - name: Prepare artifact
         run: |
           lipo -create ./bin/godot.macos.${{ matrix.target }}.x86_64 ./bin/godot.macos.${{ matrix.target }}.arm64 -output ./bin/godot.macos.${{ matrix.target }}.universal

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -147,16 +147,17 @@ jobs:
 
       - name: ⚒️ Build Editor App
         run: |
-          cp -r misc/dist/macos_tools.app Godot.app
-          mkdir -p Godot.app/Contents/MacOS
-          cp macos-editor-${{ matrix.engine }}/godot.macos.editor.universal Godot.app/Contents/MacOS/Godot
-          chmod +x Godot.app/Contents/MacOS/Godot
+          mkdir editor-app
+          cp -r misc/dist/macos_tools.app editor-app/Godot.app
+          mkdir -p editor-app/Godot.app/Contents/MacOS
+          cp macos-editor-${{ matrix.engine }}/godot.macos.editor.universal editor-app/Godot.app/Contents/MacOS/Godot
+          chmod +x editor-app/Godot.app/Contents/MacOS/Godot
 
       - name: ⏫ Upload editor app
         uses: actions/upload-artifact@v4
         with:
           name: macos-editor-app-${{ matrix.engine }}
-          path: Godot.app
+          path: editor-app
 
       - name: ⏬ Download template-release
         uses: actions/download-artifact@v4
@@ -172,14 +173,15 @@ jobs:
 
       - name: ⚒️ Build Template App
         run: |
-          cp -r misc/dist/macos_template.app .
-          mkdir -p macos_template.app/Contents/MacOS
-          cp macos-template-release-${{ matrix.engine }}/godot.macos.template_release.universal macos_template.app/Contents/MacOS/godot_macos_release.universal
-          cp macos-template-debug-${{ matrix.engine }}/godot.macos.template_debug.universal macos_template.app/Contents/MacOS/godot_macos_debug.universal
-          chmod +x macos_template.app/Contents/MacOS/godot_macos*
+          mkdir template-app
+          cp -r misc/dist/macos_template.app template-app/macos_template.app
+          mkdir -p template-app/macos_template.app/Contents/MacOS
+          cp macos-template-release-${{ matrix.engine }}/godot.macos.template_release.universal template-app/macos_template.app/Contents/MacOS/godot_macos_release.universal
+          cp macos-template-debug-${{ matrix.engine }}/godot.macos.template_debug.universal template-app/macos_template.app/Contents/MacOS/godot_macos_debug.universal
+          chmod +x template-app/macos_template.app/Contents/MacOS/godot_macos*
 
       - name: ⏫ Upload template app
         uses: actions/upload-artifact@v4
         with:
           name: macos-template-app-${{ matrix.engine }}
-          path: macos_template.app
+          path: template-app

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -39,19 +39,9 @@ jobs:
       fail-fast: false
       matrix:
         engine: [ v8,qjs-ng ]
-        os:
-          - android
-          - ios
-          - linux
-          - macos
-          - web
-          - web-nothreads
-          - windows
-        exclude:
-          - target: template-release
-            os: macos
+        os: [ android, ios, linux, macos, web, web-nothreads, windows ]
+        target: [ template-release ]
         include:
-          - target: template-release
           - target: template-debug
             os: linux
           - target: template-app
@@ -64,6 +54,9 @@ jobs:
             os: macos
           - target: editor
             os: windows
+        exclude:
+          - target: template-release
+            os: macos
     steps:
       - name: ⏬ Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -47,17 +47,20 @@ jobs:
           - web
           - web-nothreads
           - windows
+        exclude:
+          - target: template-release
+            os: macos
         include:
           - target: template-release
           - target: template-debug
             os: linux
-          - target: template-debug
+          - target: template-app
             os: macos
           - target: template-debug
             os: windows
           - target: editor
             os: linux
-          - target: editor
+          - target: editor-app
             os: macos
           - target: editor
             os: windows


### PR DESCRIPTION
Generate `.app` for MacOS to use it directly from releases