### PR TITLE
feat: CameraFeed types

### DIFF
--- a/scripts/jsb.editor/src/jsb.editor.codegen.ts
+++ b/scripts/jsb.editor/src/jsb.editor.codegen.ts
@@ -251,6 +251,32 @@ const TypeMutations: Record<string, TypeMutation> = {
             call: ["call: T"],
         },
     },
+    CameraFeed: {
+        prelude: [
+            "namespace CameraFeed {",
+            "    type FeedFormat = GDictionary<{",
+            "        width: int64",
+            "        height: int64",
+            "        format: string",
+            `        frame_numerator?: int64`,
+            `        frame_denominator?: int64`,
+            `        pixel_format?: uint32`,
+            "    }>",
+            "}",
+            "",
+        ],
+        property_overrides: {
+            formats: [
+                `get formats(): GArray<CameraFeed.FeedFormat>`,
+                `set formats(value: GArray<CameraFeed.FeedFormat>)`,
+            ],
+        },
+    },
+    CameraServer: {
+        property_overrides: {
+            feeds: mutate_return_type("GArray<CameraFeed>"),
+        },
+    },
     GArray: {
         generic_parameters: {
             T: {
@@ -645,6 +671,7 @@ const PredefinedLines = [
     "type int64 = number /* || bigint */",
     "type float32 = number",
     "type float64 = number",
+    "type uint32 = number",
     "type StringName = string",
     "type unresolved = any",
 ]

--- a/scripts/typings/godot.generated.d.ts
+++ b/scripts/typings/godot.generated.d.ts
@@ -33,6 +33,7 @@ declare module "godot" {
     }
     type byte = number
     type int32 = number
+    type uint32 = number
     type int64 = number /* || bigint */
     type float32 = number
     type float64 = number


### PR DESCRIPTION
A first pass at CameraFeed types.

Godot 4.5 will also introduce Android CameraFeed support (with a Windows PR on the way too) 🎉

Based on https://github.com/godotengine/godot/blob/master/servers/camera/camera_feed.h#L64-L71 and looking at the platform-specific code. CameraFeed is sub-classed so _technically_ they can return whatever they want. I haven't typed `set_format` because it varies significantly depending on which platform.

_Honestly camera support is a pretty dark area of Godot 😅 Permissions are implemented via explicit permission requests on Android and iOS, but on Mac for example (which also has a permission prompt), the permission request "just happens" when you try use the camera. Not really relevant to these types, but it's just generally worth noting, the APIs "aren't great"._