### PR TITLE
feat: Bumped default tsconfig target from es2016 to es2022

### DIFF
--- a/.changeset/bright-doodles-change.md
+++ b/.changeset/bright-doodles-change.md
@@ -1,0 +1,9 @@
+---
+"@godot-js/editor": patch
+---
+
+**Feature:** Bumped default tsconfig target from es2016 to es2022
+
+All supported runtimes ought to support the 2022 standard. You can
+still manually change the target if desired. This change is to
+provide a better user experience by default.

--- a/scripts/jsb.editor/tsconfig.json
+++ b/scripts/jsb.editor/tsconfig.json
@@ -12,7 +12,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */

--- a/scripts/jsb.runtime/tsconfig.json
+++ b/scripts/jsb.runtime/tsconfig.json
@@ -12,7 +12,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */

--- a/scripts/jsb.static/tsconfig.json
+++ b/scripts/jsb.static/tsconfig.json
@@ -12,7 +12,7 @@
       // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
   
       /* Language and Environment */
-      "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+      "target": "es2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
       // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
       // "jsx": "preserve",                                /* Specify what JSX code is generated. */
       // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */

--- a/scripts/presets/jsconfig.json.txt
+++ b/scripts/presets/jsconfig.json.txt
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
         "module": "CommonJS",
-        "target": "es2016"
+        "target": "es2022"
     }
 }

--- a/scripts/presets/tsconfig.json.txt
+++ b/scripts/presets/tsconfig.json.txt
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */

--- a/tests/project/tsconfig.json
+++ b/tests/project/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */


### PR DESCRIPTION
All supported runtimes ought to support the 2022 standard. Can still manually change the target if desired. This change is to provide a better user experience by default.