### PR TITLE
fix: Background/async resource loading where scripts are present.

### DIFF
--- a/.changeset/giant-ducks-talk.md
+++ b/.changeset/giant-ducks-talk.md
@@ -1,0 +1,17 @@
+---
+"@godot-js/editor": patch
+---
+
+fix: Background/async resource loading where scripts are present.
+
+Shadow script instance replacement was failing due to calling the
+wrong GodotJSScript::instance_create() overload. The overloads
+have been replaced with separate functions to mitigate future
+occurrences.
+
+Additionally, shadow script instance replacement was not properly
+handling user types, only built-ins. This broke in a subtle hard
+to debug fashion, whereby you received back a valid JS class
+instance for the expected Godot object, however its prototype
+chain was incomplete. The JS object was an instance of the base
+Godot native object rather than the script on the object.

--- a/bridge/jsb_class_info.cpp
+++ b/bridge/jsb_class_info.cpp
@@ -251,7 +251,7 @@ namespace jsb
         if (script.is_valid())
         {
             jsb_unused(script->can_instantiate()); // make it loaded immediately
-            const ScriptInstance* script_instance = script->instance_create(p_self, p_env->flags_ & Environment::EnvironmentFlags::EF_Shadow);
+            const ScriptInstance* script_instance = script->instance_and_native_object_create(p_self, p_env->flags_ & Environment::EnvironmentFlags::EF_Shadow);
             jsb_unused(script_instance);
             jsb_check(script_instance);
         }

--- a/bridge/jsb_environment.cpp
+++ b/bridge/jsb_environment.cpp
@@ -787,7 +787,7 @@ namespace jsb
                     List<Pair<StringName, Variant>> state;
                     script_instance->get_property_state(state);
                     p_pointer->set_script_instance(nullptr);
-                    ScriptInstance* new_script_instance = script->instance_create(p_object, p_pointer);
+                    ScriptInstance* new_script_instance = script->instance_create(p_object, p_pointer, false);
                     jsb_check(new_script_instance);
                     jsb_unused(new_script_instance);
                     for (const Pair<StringName, Variant>& pair : state)

--- a/weaver/jsb_script.cpp
+++ b/weaver/jsb_script.cpp
@@ -83,7 +83,7 @@ StringName GodotJSScript::get_instance_base_type() const
     return is_valid() ? script_class_info_.native_class_name : StringName();
 }
 
-ScriptInstance* GodotJSScript::instance_create(const v8::Local<v8::Object>& p_this, bool p_is_temp_allowed)
+ScriptInstance* GodotJSScript::instance_and_native_object_create(const v8::Local<v8::Object>& p_this, bool p_is_temp_allowed)
 {
     jsb_check(is_valid());
     jsb_check(loaded_);

--- a/weaver/jsb_script.h
+++ b/weaver/jsb_script.h
@@ -62,9 +62,11 @@ public:
     Error load_source_code(const String &p_path);
     void load_module_if_missing();
 
-    // Creates a ScriptInstance and associates it with an existing JS object (instance of the script's JS class).
+    // Creates a ScriptInstance (for an existing Godot native object) and associates the ScriptInstance with an existing JS object (instance of the script's JS class).
     ScriptInstance* instance_create(const v8::Local<v8::Object>& p_this, Object* p_owner, bool p_is_temp_allowed);
-    ScriptInstance* instance_create(const v8::Local<v8::Object>& p_this, bool p_is_temp_allowed);
+
+    // Creates a ScriptInstance (and a NEW Godot native object) and associates the ScriptInstance with an existing JS object (instance of the script's JS class).
+    ScriptInstance* instance_and_native_object_create(const v8::Local<v8::Object>& p_this, bool p_is_temp_allowed);
 
     // Creates a ScriptInstance and associates it with a newly constructed JS object (instance of script's class).
     ScriptInstance* instance_construct(Object* p_this, bool p_is_temp_allowed, const Variant **p_args = nullptr, int p_argcount = 0);

--- a/weaver/jsb_script_instance.h
+++ b/weaver/jsb_script_instance.h
@@ -104,7 +104,6 @@ public:
 
     virtual void notification(int p_notification, bool p_reversed = false) override
     {
-        JSB_LOG(Error, "now allowed");
     }
 
     virtual const Variant get_rpc_config() const override { return script_->get_rpc_config(); }


### PR DESCRIPTION
Shadow script instance replacement was failing due to calling the wrong GodotJSScript::instance_create() overload. The overloads have been replaced with separate functions to mitigate future occurrences.

Additionally, shadow script instance replacement was not properly handling user types, only built-ins. This broke in a subtle hard to debug fashion, whereby you received back a valid JS class instance for the expected Godot object, however its prototype chain was incomplete. The JS object was an instance of the base Godot native object rather than the script on the object.