### PR TITLE
fix: JavaScriptTimerAction invocation crash.

### DIFF
--- a/.changeset/tangy-pugs-tell.md
+++ b/.changeset/tangy-pugs-tell.md
@@ -1,0 +1,5 @@
+---
+"@godot-js/editor": patch
+---
+
+fix: setTimeout/setInterval invocation crash

--- a/bridge/jsb_timer_action.cpp
+++ b/bridge/jsb_timer_action.cpp
@@ -6,7 +6,9 @@ namespace jsb
 {
     void JavaScriptTimerAction::operator()(v8::Isolate* isolate)
     {
-        const v8::Local<v8::Function> func = function_.Get(isolate);
+        jsb_checkf(function_, "Attempt made to call a moved/unassigned JavaScriptTimerAction");
+
+        const v8::Local<v8::Function> func = function_->Get(isolate);
         const v8::Local<v8::Context> context = func->GetCreationContextChecked();
 
         jsb_checkf(Environment::wrap(context), "timer triggered after Environment disposed");

--- a/bridge/jsb_timer_action.h
+++ b/bridge/jsb_timer_action.h
@@ -7,15 +7,17 @@ namespace jsb
 {
     struct JavaScriptTimerAction
     {
-        jsb_force_inline JavaScriptTimerAction() = default;
-
-        jsb_force_inline JavaScriptTimerAction(v8::Global<v8::Function>&& p_func, int p_argc) : function_(std::move(p_func)), argc_(p_argc)
+        jsb_force_inline JavaScriptTimerAction(): function_(nullptr), argc_(0), argv_(nullptr)
         {
+        }
+
+        jsb_force_inline JavaScriptTimerAction(v8::Global<v8::Function>&& p_func, int p_argc) : argc_(p_argc)
+        {
+            function_ = new v8::Global<v8::Function>(std::move(p_func));
+
             if (p_argc > 0)
             {
-                //NOTE unsafe
-                argv_ = (v8::Global<v8::Value>*) memalloc(sizeof(v8::Global<v8::Value>) * p_argc);
-                memset((void*) argv_, 0, sizeof(v8::Global<v8::Value>) * p_argc);
+                argv_ = new v8::Global<v8::Value>[p_argc];
             }
             else
             {
@@ -25,34 +27,41 @@ namespace jsb
 
         jsb_force_inline ~JavaScriptTimerAction()
         {
-            if (argc_ > 0)
-            {
-                //NOTE unsafe
-                for (int index = 0 ; index < argc_; ++index)
-                {
-                    argv_[index].Reset();
-                }
-                memfree(argv_);
-            }
-            function_.Reset();
+            delete function_;
+            delete[] argv_;
         }
 
+        JavaScriptTimerAction(JavaScriptTimerAction& p_other) = delete;
+
         jsb_force_inline JavaScriptTimerAction(JavaScriptTimerAction&& p_other) noexcept
-            : function_(std::move(p_other.function_)), argc_(p_other.argc_), argv_(p_other.argv_)
+            : function_(p_other.function_), argc_(p_other.argc_), argv_(p_other.argv_)
         {
+            p_other.function_ = nullptr;
             p_other.argc_ = 0;
+            p_other.argv_ = nullptr;
         }
+
+        JavaScriptTimerAction& operator=(JavaScriptTimerAction& p_other) = delete;
 
         jsb_force_inline JavaScriptTimerAction& operator=(JavaScriptTimerAction&& p_other) noexcept
         {
-            function_ = std::move(p_other.function_);
-            argc_ = p_other.argc_;
-            argv_ = p_other.argv_;
-            p_other.argc_ = 0;
+            if (this != &p_other)
+            {
+                delete function_;
+                delete[] argv_;
+
+                function_ = p_other.function_;
+                argc_ = p_other.argc_;
+                argv_ = p_other.argv_;
+
+                p_other.function_ = nullptr;
+                p_other.argc_ = 0;
+                p_other.argv_ = nullptr;
+            }
             return *this;
         }
 
-        jsb_force_inline explicit operator bool() const { return !function_.IsEmpty(); }
+        jsb_force_inline explicit operator bool() const { return function_ && !function_->IsEmpty(); }
 
         jsb_force_inline void store(int index, v8::Global<v8::Value>&& value)
         {
@@ -63,7 +72,7 @@ namespace jsb
         void operator()(v8::Isolate* isolate);
 
     private:
-        v8::Global<v8::Function> function_;
+        v8::Global<v8::Function>* function_;
         int argc_;
         v8::Global<v8::Value>* argv_;
     };


### PR DESCRIPTION
Previously, a crash would occur on the following line:

```cpp
const v8::Local<v8::Context> context = func->GetCreationContextChecked();
```

This is because SArray does not copy/move upon resizing, instead the raw memory is copied. However, v8::Global (where func came from) is not POD. You fundamentally cannot move them around in memory because their design requires that V8 keep a running record of all references for when the slot is moved (with generational GC, this sort of thing happens frequently).

Solution is to allocate our v8::Global on the heap and store a pointer to it. The pointer can safely be moved around in memory without issue.