### PR TITLE
fix: Actually fix JavaScriptTimerAction invocation crash

### DIFF
--- a/bridge/jsb_essentials.cpp
+++ b/bridge/jsb_essentials.cpp
@@ -167,7 +167,8 @@ namespace jsb
             Environment::wrap(isolate)->get_timer_manager().set_timer(handle,
                 JavaScriptTimerAction(v8::Global<v8::Function>(isolate, func), 0), rate > 0 ? rate : 0, loop);
         }
-        info.GetReturnValue().Set((int32_t) handle);
+        // TODO: V8 update. Once we update V8 past 12.6.221 we can skip the cast to double
+        info.GetReturnValue().Set((double) (int64_t) handle);
     }
 
     void _clear_timer(const v8::FunctionCallbackInfo<v8::Value>& info)

--- a/bridge/jsb_timer_action.cpp
+++ b/bridge/jsb_timer_action.cpp
@@ -6,7 +6,11 @@ namespace jsb
 {
     void JavaScriptTimerAction::operator()(v8::Isolate* isolate)
     {
-        jsb_checkf(function_, "Attempt made to call a moved/unassigned JavaScriptTimerAction");
+        if (!function_)
+        {
+            JSB_LOG(Warning, "Ignored attempt to execute a unassigned/moved/destroyed JavaScriptTimerAction");
+            return;
+        }
 
         const v8::Local<v8::Function> func = function_->Get(isolate);
         const v8::Local<v8::Context> context = func->GetCreationContextChecked();

--- a/bridge/jsb_timer_action.h
+++ b/bridge/jsb_timer_action.h
@@ -5,6 +5,9 @@
 
 namespace jsb
 {
+    /**
+     * This struct is *not* POD, but aims to be compatible with SArray's memory relocation logic.
+     */
     struct JavaScriptTimerAction
     {
         jsb_force_inline JavaScriptTimerAction(): function_(nullptr), argc_(0), argv_(nullptr)
@@ -29,6 +32,8 @@ namespace jsb
         {
             delete function_;
             delete[] argv_;
+            function_ = nullptr;
+            argv_ = nullptr;
         }
 
         JavaScriptTimerAction(JavaScriptTimerAction& p_other) = delete;

--- a/internal/jsb_format.h
+++ b/internal/jsb_format.h
@@ -6,10 +6,11 @@
 
 namespace jsb::internal
 {
-    template<typename T> struct TFormat            { static Variant from(const T& p_item) { return p_item; } };
-    template<>           struct TFormat<Index64>   { static Variant from(const Index64& p_item) { return *p_item; } };
-    template<>           struct TFormat<Index32>   { static Variant from(const Index32& p_item) { return *p_item; } };
-    template<>           struct TFormat<uintptr_t> { static Variant from(const uintptr_t& p_item) { return Variant((uint64_t) p_item); } };
+    template<typename T> struct TFormat                { static Variant from(const T& p_item) { return p_item; } };
+    template<>           struct TFormat<IndexSafe64>   { static Variant from(const IndexSafe64& p_item) { return *p_item; } };
+    template<>           struct TFormat<Index64>       { static Variant from(const Index64& p_item) { return *p_item; } };
+    template<>           struct TFormat<Index32>       { static Variant from(const Index32& p_item) { return *p_item; } };
+    template<>           struct TFormat<uintptr_t>     { static Variant from(const uintptr_t& p_item) { return Variant((uint64_t) p_item); } };
     template<typename T> static Variant convert(const T& p_item) { return TFormat<T>::from(p_item); }
 
     template <typename... VarArgs>

--- a/internal/jsb_sindex.h
+++ b/internal/jsb_sindex.h
@@ -75,8 +75,12 @@ namespace jsb::internal
         UnderlyingType packed_;
     };
 
+    // Allocates 64 bits, but only the lower 52 are used. This is the range that can be safely stored in a JS number.
+    // index(0, 4_294_967_295) revision(1, 4_294_967_295)
+    typedef TIndex<uint64_t, 20, 0xfffff> IndexSafe64;
+
     // do not really support the index bigger than int32_t.MaxValue
-    // /*if unsigned*/ index(0, 4_294_967_295) revision(1, 4_294_967_295)
+    // /*if unsigned*/ index(0, 4_294_967_295) revision(1, 1_048_575)
     typedef TIndex<uint64_t, 32, 0xffffffff> Index64;
 
     // index(0, 67_108_863) revision(1, 63)


### PR DESCRIPTION
Previous fix was a red herring. Whilst technically there was an issue there, it turned out not to be the cause of the crash that I've repeatedly ran into.

The real issue was that SArray isn't really a safe data structure, by design. Smaller revision ranges exacerbate the data structure's limitations. For some use cases a small revision range will be fine, but timers are likely a prime example of an API where a small revision range is NOT fine.

This is because the way timers are used in JavaScript is often as timeouts, which is why the API is called setTimeout(). Often the user schedules a timeout and it's never expected to fire. Instead clearTimeout will be called when some other operation returns before the timeout is reached. This means timers are frequently being inserted and deleted. SArray by design will reuse indexes, when this occurs the revision is incremented. However, the Index32 data structure only permits 64 revisions. That number is likely to (and in my case definitely does) wrap around frequently.

That on its lonesome isn't an issue. What's problematic is that the timer manager uses an efficient wheel data structure built atop SArray. Scheduled timers are added to one of many wheels and into the SArray index of all scheduled timers. When a timer is cleared, the wheels are not touched at all, only the used timer SArray is modified. The idea being that later on when it's time to execute the relevant timers stored in (part of) a wheel, we just check to see if index in the wheel resolves to a timer in our used/scheduled timer SArray. With a small revision range, we frequently end up reusing both and index AND matching revision.

This leads to both early firing of timers AND firing of timers that have since been destructed i.e. cause the crash.

This PR swaps from using 32-bit index+revisions to 52-bit index+revisions. 20 bits of which are reserved for the revision. So now we can have over 1 million revisions before wrapping around.

It's now substantially unlikely for index re-use to happen. HOWEVER, in theory, it COULD still occur. Suppose that in this extremely unlikely circumstance our timer were to fire too early. That's not ideal, but is probably a risk we can live with. What we can't accept is the risk of an outright crash. So we've also implemented protection in JavaScriptTimerAction itself. Basically its destructor now effectively marks itself as being destroyed. The execution logic detects this and bails out, evading the crash.