### PR TITLE
Codegen - Fix for primitive types not being `any`

### DIFF
--- a/scripts/jsb.editor/src/jsb.editor.codegen.ts
+++ b/scripts/jsb.editor/src/jsb.editor.codegen.ts
@@ -2902,7 +2902,7 @@ export class TypeDB {
         return true;
     }
 
-    make_classname(class_name: string, internal?: boolean): string {
+    make_classname(class_name: string, internal?: boolean, type?: Variant.Type): string {
         const types = this;
 
         if (class_name.indexOf(".") > 0) {
@@ -2950,6 +2950,11 @@ export class TypeDB {
         if (class_name in types.globals) {
             return class_name;
         }
+
+        if (type && RemappedPrimitiveTypeNames[type] != null) {
+            return RemappedPrimitiveTypeNames[type]!
+        }
+
         console.warn("undefined class", class_name);
         return `any /*${class_name}*/`;
     }
@@ -2961,7 +2966,7 @@ export class TypeDB {
 
         if (info.hint == godot.PropertyHint.PROPERTY_HINT_RESOURCE_TYPE) {
             console.assert(info.hint_string.length != 0, "at least one valid class_name expected");
-            return null_prefix + info.hint_string.split(',').map(name => this.make_classname(name, true)).join(" | ");
+            return null_prefix + info.hint_string.split(',').map(name => this.make_classname(name, true, info.type)).join(" | ");
         }
 
         //NOTE there are infos with `.class_name == bool` instead of `.type` only, they will be remapped in `make_classname`
@@ -2999,7 +3004,7 @@ export class TypeDB {
             return `any /*unhandled: ${info.type}*/`;
         }
 
-        return null_prefix + this.make_classname(info.class_name);
+        return null_prefix + this.make_classname(info.class_name, undefined, info.type);
     }
 
     make_arg(info: PropertyInfo, optional?: boolean): string {


### PR DESCRIPTION
Hello 👋,

There was a small bug preventing primitive type aliases from being typed in the codegen with their correct types and they were falling back to `any`.

Example of codegen before this change (`Tabs` is just an alias for `int` but that is not recognized):

<img height="200" alt="before fix screenshot" src="https://github.com/user-attachments/assets/a534c3ff-73cd-4d47-bb27-b54650edf694" />


This PR updates the codegen to check the primitives map before returning any, the result is:

<img height="200" alt="after fix screenshot" src="https://github.com/user-attachments/assets/7cdfce14-6c81-4081-a940-1e3675293353" />

I put the new logic inside `make_classname` but I realize this may not be the best place since primitives are not classes - if there's a better place, please let me know and I will move.

Thanks!
