### PR TITLE
Codegen - Fix properties in interfaces starting with numbers

### DIFF
--- a/scripts/jsb.editor/src/jsb.editor.codegen.ts
+++ b/scripts/jsb.editor/src/jsb.editor.codegen.ts
@@ -835,7 +835,7 @@ function replace_var_name(name: string) {
     return typeof rep !== "undefined" ? rep : name;
 }
 
-const needs_quotes_regex = /^(?![$_])[^\w$]|[^\w$]/;
+const needs_quotes_regex = /^(?![$_A-Za-z])|[^\w$]/;
 const quoted_escape_map: Record<string, string> = {
     '"': '\\"',
     '\\': '\\\\',
@@ -2027,7 +2027,7 @@ class TypeDescriptorWriter extends BufferingWriter {
                         return;
                     }
 
-                    indent.line(`"${name_string(key)}"${value.optional ? '?' : ''}: `);
+                    indent.line(`${name_string(key)}${value.optional ? '?' : ''}: `);
                     const prop_writer = new TypeDescriptorWriter(indent, true);
                     prop_writer.serialize_type_descriptor(value);
                     prop_writer.finish();


### PR DESCRIPTION
Hello again 👋,

This PR fixes a small issue when doing codegen for scene node interfaces, if a node name starts with a number, the entire file becomes a syntax error, although starting a property name with a number in typescript is valid, so this PR wraps them with quotes to avoid any syntax errors.

Example before the fix:
<img width="2114" height="1232" alt="CleanShot 2025-10-31 at 15 20 39@2x" src="https://github.com/user-attachments/assets/31dfee19-0872-482f-b369-c515ce7f209c" />

Example after fix:
<img width="2266" height="1270" alt="CleanShot 2025-11-02 at 09 33 45@2x" src="https://github.com/user-attachments/assets/d4020f46-1a18-4c0b-990f-bec5dacd920d" />
