### PR TITLE
chore: Ensure embedded .js files are built by default

### DIFF
--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -22,6 +22,7 @@ env:
     debug_symbols=no
     module_text_server_fb_enabled=yes
     swappy=yes
+    skip_js_runtime=yes
   # 4.5+
   # Ideally we'd use dev_mode=yes. Unfortunately, v8 headers contain warnings. So we manually set some dev_mode options.
   SCONS_FLAGS: >-
@@ -32,6 +33,7 @@ env:
     module_text_server_fb_enabled=yes
     tests=no
     swappy=yes
+    skip_js_runtime=yes
 
 # We only build template release - most developers will use a desktop device for editor
 jobs:
@@ -96,10 +98,10 @@ jobs:
         uses: ./.github/actions/godot-build
         with:
           sconsflags: >-
-            ${{ env.SCONSFLAGS }}             
-            ${{ matrix.engine == 'qjs-ng' && 'use_quickjs_ng=yes' || '' }} 
-            deprecated=no 
-            ndk_platform=android-24 
+            ${{ env.SCONSFLAGS }}
+            ${{ matrix.engine == 'qjs-ng' && 'use_quickjs_ng=yes' || '' }}
+            deprecated=no
+            ndk_platform=android-24
             generate_apk=yes
           platform: android
           target: ${{ matrix.target }}
@@ -110,7 +112,7 @@ jobs:
         uses: ./.github/actions/godot-build
         with:
           scons-flags: >-
-            ${{ env.SCONS_FLAGS }}             
+            ${{ env.SCONS_FLAGS }}
             ${{ matrix.engine == 'qjs-ng' && 'use_quickjs_ng=yes' || '' }}
           platform: android
           target: ${{ matrix.target }}

--- a/.github/workflows/build_ios.yml
+++ b/.github/workflows/build_ios.yml
@@ -19,6 +19,7 @@ env:
   SCONSFLAGS: >-
     debug_symbols=no
     module_text_server_fb_enabled=yes
+    skip_js_runtime=yes
   # 4.5+
   # Ideally we'd use dev_mode=yes. Unfortunately, v8 headers contain warnings. So we manually set some dev_mode options.
   SCONS_FLAGS: >-
@@ -28,6 +29,7 @@ env:
     module_text_server_fb_enabled=yes
     tests=no
     debug_symbols=no
+    skip_js_runtime=yes
 
 jobs:
   ios-template:
@@ -76,7 +78,7 @@ jobs:
         uses: ./.github/actions/godot-build
         with:
           sconsflags: >-
-            ${{ env.SCONSFLAGS }}             
+            ${{ env.SCONSFLAGS }}
             ${{ matrix.engine == 'qjs-ng' && 'use_quickjs_ng=yes' || '' }}
           platform: ios
           target: ${{ matrix.target }}
@@ -87,7 +89,7 @@ jobs:
         uses: ./.github/actions/godot-build
         with:
           scons-flags: >-
-            ${{ env.SCONS_FLAGS }}             
+            ${{ env.SCONS_FLAGS }}
             ${{ matrix.engine == 'qjs-ng' && 'use_quickjs_ng=yes' || '' }}
           platform: ios
           target: ${{ matrix.target }}

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -19,6 +19,7 @@ env:
   SCONSFLAGS: >-
     module_text_server_fb_enabled=yes
     strict_checks=yes
+    skip_js_runtime=yes
   # 4.5
   # Ideally we'd use dev_mode=yes. Unfortunately, v8 headers contain warnings. So we manually set some dev_mode options.
   SCONS_FLAGS: >-
@@ -27,6 +28,7 @@ env:
     strict_checks=yes
     module_text_server_fb_enabled=yes
     "accesskit_sdk_path=${{ github.workspace }}/accesskit-c-0.17.0/"
+    skip_js_runtime=yes
 #  ASAN_OPTIONS: color=always:print_suppressions=1:suppressions=${{ github.workspace }}/misc/error_suppressions/asan.txt
 #  LSAN_OPTIONS: color=always:print_suppressions=1:suppressions=${{ github.workspace }}/misc/error_suppressions/lsan.txt
 #  TSAN_OPTIONS: color=always:print_suppressions=1:suppressions=${{ github.workspace }}/misc/error_suppressions/tsan.txt
@@ -109,9 +111,9 @@ jobs:
         uses: ./.github/actions/godot-build
         with:
           sconsflags: >-
-            ${{ env.SCONSFLAGS }} 
-            ${{ matrix.target != 'editor' && 'debug_symbols=no' || '' }} 
-            ${{ matrix.engine == 'qjs-ng' && 'use_quickjs_ng=yes' || '' }} 
+            ${{ env.SCONSFLAGS }}
+            ${{ matrix.target != 'editor' && 'debug_symbols=no' || '' }}
+            ${{ matrix.engine == 'qjs-ng' && 'use_quickjs_ng=yes' || '' }}
             ${{ !inputs.release && matrix.target == 'editor' && 'tests=yes' || '' }}
           platform: linuxbsd
           target: ${{ matrix.target }}
@@ -122,9 +124,9 @@ jobs:
         uses: ./.github/actions/godot-build
         with:
           scons-flags: >-
-            ${{ env.SCONS_FLAGS }} 
-            ${{ matrix.target != 'editor' && 'debug_symbols=no' || '' }} 
-            ${{ matrix.engine == 'qjs-ng' && 'use_quickjs_ng=yes' || '' }} 
+            ${{ env.SCONS_FLAGS }}
+            ${{ matrix.target != 'editor' && 'debug_symbols=no' || '' }}
+            ${{ matrix.engine == 'qjs-ng' && 'use_quickjs_ng=yes' || '' }}
             ${{ !inputs.release && matrix.target == 'editor' && 'tests=yes' || '' }}
           platform: linuxbsd
 

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -19,6 +19,7 @@ env:
   SCONSFLAGS: >-
     module_text_server_fb_enabled=yes
     strict_checks=yes
+    skip_js_runtime=yes
   # 4.5
   # Ideally we'd use dev_mode=yes. Unfortunately, v8 headers contain warnings. So we manually set some dev_mode options.
   SCONS_FLAGS: >-
@@ -27,6 +28,7 @@ env:
     strict_checks=yes
     module_text_server_fb_enabled=yes
     "accesskit_sdk_path=${{ github.workspace }}/accesskit-c-0.17.0/"
+    skip_js_runtime=yes
 
 jobs:
   build-macos:
@@ -107,11 +109,11 @@ jobs:
         uses: ./.github/actions/godot-build
         with:
           sconsflags: >-
-            ${{ env.SCONSFLAGS }} 
-            ${{ matrix.target != 'editor' && 'debug_symbols=no' || '' }} 
-            ${{ matrix.engine == 'qjs-ng' && 'use_quickjs_ng=yes' || '' }} 
-            arch=x86_64 
-            vulkan=${{ steps.vulkan-sdk.outputs.VULKAN_ENABLED }} 
+            ${{ env.SCONSFLAGS }}
+            ${{ matrix.target != 'editor' && 'debug_symbols=no' || '' }}
+            ${{ matrix.engine == 'qjs-ng' && 'use_quickjs_ng=yes' || '' }}
+            arch=x86_64
+            vulkan=${{ steps.vulkan-sdk.outputs.VULKAN_ENABLED }}
             ${{ !inputs.release && matrix.target == 'editor' && 'tests=yes' || '' }}
           platform: macos
           target: ${{ matrix.target }}
@@ -122,11 +124,11 @@ jobs:
         uses: ./.github/actions/godot-build
         with:
           scons-flags: >-
-            ${{ env.SCONSFLAGS }} 
-            ${{ matrix.target != 'editor' && 'debug_symbols=no' || '' }} 
-            ${{ matrix.engine == 'qjs-ng' && 'use_quickjs_ng=yes' || '' }} 
-            arch=x86_64 
-            vulkan=${{ steps.vulkan-sdk.outputs.VULKAN_ENABLED }} 
+            ${{ env.SCONSFLAGS }}
+            ${{ matrix.target != 'editor' && 'debug_symbols=no' || '' }}
+            ${{ matrix.engine == 'qjs-ng' && 'use_quickjs_ng=yes' || '' }}
+            arch=x86_64
+            vulkan=${{ steps.vulkan-sdk.outputs.VULKAN_ENABLED }}
             ${{ !inputs.release && matrix.target == 'editor' && 'tests=yes' || '' }}
           platform: macos
           target: ${{ matrix.target }}
@@ -136,11 +138,11 @@ jobs:
         uses: ./.github/actions/godot-build
         with:
           sconsflags: >-
-            ${{ env.SCONS_FLAGS }} 
-            ${{ matrix.target != 'editor' && 'debug_symbols=no' || '' }} 
-            ${{ matrix.engine == 'qjs-ng' && 'use_quickjs_ng=yes' || '' }} 
-            arch=arm64 
-            vulkan=${{ steps.vulkan-sdk.outputs.VULKAN_ENABLED }} 
+            ${{ env.SCONS_FLAGS }}
+            ${{ matrix.target != 'editor' && 'debug_symbols=no' || '' }}
+            ${{ matrix.engine == 'qjs-ng' && 'use_quickjs_ng=yes' || '' }}
+            arch=arm64
+            vulkan=${{ steps.vulkan-sdk.outputs.VULKAN_ENABLED }}
             ${{ !inputs.release && matrix.target == 'editor' && 'tests=yes' || '' }}
           platform: macos
           target: ${{ matrix.target }}
@@ -151,11 +153,11 @@ jobs:
         uses: ./.github/actions/godot-build
         with:
           scons-flags: >-
-            ${{ env.SCONS_FLAGS }} 
-            ${{ matrix.target != 'editor' && 'debug_symbols=no' || '' }} 
-            ${{ matrix.engine == 'qjs-ng' && 'use_quickjs_ng=yes' || '' }} 
-            arch=arm64 
-            vulkan=${{ steps.vulkan-sdk.outputs.VULKAN_ENABLED }} 
+            ${{ env.SCONS_FLAGS }}
+            ${{ matrix.target != 'editor' && 'debug_symbols=no' || '' }}
+            ${{ matrix.engine == 'qjs-ng' && 'use_quickjs_ng=yes' || '' }}
+            arch=arm64
+            vulkan=${{ steps.vulkan-sdk.outputs.VULKAN_ENABLED }}
             ${{ !inputs.release && matrix.target == 'editor' && 'tests=yes' || '' }}
           platform: macos
           target: ${{ matrix.target }}

--- a/.github/workflows/build_web.yml
+++ b/.github/workflows/build_web.yml
@@ -24,6 +24,7 @@ env:
     lto=none
     use_assertions=no
     use_safe_heap=yes
+    skip_js_runtime=yes
   # 4.5+
   # Ideally we'd use dev_mode=yes. Unfortunately, v8 headers contain warnings. So we manually set some dev_mode options.
   SCONS_FLAGS: >-
@@ -33,6 +34,7 @@ env:
     tests=no
     debug_symbols=no
     use_closure_compiler=yes
+    skip_js_runtime=yes
 
 jobs:
   web-template:
@@ -115,7 +117,7 @@ jobs:
         uses: ./.github/actions/godot-build
         with:
           sconsflags: >-
-            ${{ env.SCONSFLAGS }}             
+            ${{ env.SCONSFLAGS }}
             ${{ matrix.engine == 'qjs-ng' && 'use_quickjs_ng=yes' || '' }}
           platform: web
           target: ${{ matrix.target }}
@@ -126,7 +128,7 @@ jobs:
         uses: ./.github/actions/godot-build
         with:
           scons-flags: >-
-            ${{ env.SCONS_FLAGS }}             
+            ${{ env.SCONS_FLAGS }}
             ${{ matrix.engine == 'qjs-ng' && 'use_quickjs_ng=yes' || '' }}
           platform: web
           target: ${{ matrix.target }}

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -23,6 +23,7 @@ env:
     strict_checks=yes
     debug_symbols=no
     "angle_libs=${{ github.workspace }}/"
+    skip_js_runtime=yes
   # 4.5+
   # Ideally we'd use dev_mode=yes. Unfortunately, v8 headers contain warnings. So we manually set some dev_mode options.
   SCONS_FLAGS: >-
@@ -34,6 +35,7 @@ env:
     d3d12=yes
     "angle_libs=${{ github.workspace }}/"
     "accesskit_sdk_path=${{ github.workspace }}/accesskit-c-0.17.0/"
+    skip_js_runtime=yes
   SCONS_CACHE_MSVC_CONFIG: true
   PYTHONIOENCODING: utf8
 
@@ -117,9 +119,9 @@ jobs:
         uses: ./.github/actions/godot-build
         with:
           sconsflags: >-
-            ${{ env.SCONSFLAGS }} 
-            ${{ matrix.target == 'editor' && 'vsproj=yes vsproj_gen_only=no windows_subsystem=console' || '' }} 
-            ${{ matrix.engine == 'qjs-ng' && 'use_quickjs_ng=yes' || '' }} 
+            ${{ env.SCONSFLAGS }}
+            ${{ matrix.target == 'editor' && 'vsproj=yes vsproj_gen_only=no windows_subsystem=console' || '' }}
+            ${{ matrix.engine == 'qjs-ng' && 'use_quickjs_ng=yes' || '' }}
             ${{ !inputs.release && matrix.target == 'editor' && 'tests=yes' || '' }}
           platform: windows
           target: ${{ matrix.target }}
@@ -130,9 +132,9 @@ jobs:
         uses: ./.github/actions/godot-build
         with:
           scons-flags: >-
-            ${{ env.SCONS_FLAGS }} 
-            ${{ matrix.target == 'editor' && 'vsproj=yes vsproj_gen_only=no windows_subsystem=console' || '' }} 
-            ${{ matrix.engine == 'qjs-ng' && 'use_quickjs_ng=yes' || '' }} 
+            ${{ env.SCONS_FLAGS }}
+            ${{ matrix.target == 'editor' && 'vsproj=yes vsproj_gen_only=no windows_subsystem=console' || '' }}
+            ${{ matrix.engine == 'qjs-ng' && 'use_quickjs_ng=yes' || '' }}
             ${{ !inputs.release && matrix.target == 'editor' && 'tests=yes' || '' }}
           platform: windows
           target: ${{ matrix.target }}

--- a/SCsub
+++ b/SCsub
@@ -466,6 +466,13 @@ module_obj = []
 print(f"godot engine: {version_info['major']}.{version_info['minor']}")
 check("regex" in env.module_list, "Currently, the 'regex' module is required for using GodotJS. Please rebuild the engine with it enabled.")
 
+# Build JS files before generating
+if not env["skip_js_runtime"]:
+    pnpm_resolved = shutil.which("pnpm")
+    pnpm_command = [pnpm_resolved] if env["tests"] else [pnpm_resolved, "--filter=!./tests/project"]
+    print(subprocess.run([*pnpm_command, "install"], check=True))
+    print(subprocess.run([*pnpm_command, "build"], check=True))
+
 if v8_support is not None:
     # it seems godot always links MT_StaticRelease even if env["dev_build"]
     # it seems v8_monolith must be compiled with `use_rtti=true` explicitly, or the linker will fail on `v8::ArrayBuffer::Allocator`
@@ -565,6 +572,8 @@ if quickjs_support is not None:
     env_jsb.add_source_files(module_obj, "impl/quickjs/*.cpp")
 
 if is_defined("JSB_WITH_WEB"):
+    check(os.path.exists("impl/web/js"), "impl/web/js (GodotJS web bridge) has not been built")
+
     print_warning("web.impl is experimental and may not work as expected")
 
     env_jsb.add_source_files(module_obj, "impl/web/*.cpp")
@@ -583,10 +592,7 @@ if is_defined("JSB_WITH_JAVASCRIPTCORE"):
         if env.msvc and env["vsproj"]:
             env.Append(CPPPATH=[f"#modules/{module_name}/impl/jsc/_NOT_FOR_INCLUDE_"])
 
-# Build JS files before generating
-if not os.path.exists("scripts/out"):
-    print(subprocess.run(["pnpm", "install"], shell=True, check=True))
-    print(subprocess.run(["pnpm", "build"], shell=True, check=True))
+check(os.path.exists("scripts/out"), "scripts/out (GodotJS JavaScript runtime) has not been built")
 
 generate_code([\
         # presets for runtime

--- a/config.py
+++ b/config.py
@@ -13,6 +13,7 @@ def get_opts(platform):
     from SCons.Variables import BoolVariable, EnumVariable
 
     return [
+        BoolVariable("skip_js_runtime", "Skip building GodotJS JavaScript runtime files", False),
         BoolVariable("use_typescript", "Build with typescript support (enabled by default)", True),
         BoolVariable("use_jsc", "Prefer to use JavaScriptCore (only for macos and ios)", False),
         BoolVariable("use_quickjs", "Prefer to use QuickJS rather than the default VM on the current platform", False),
@@ -24,4 +25,4 @@ def configure(env):
 
 def get_icons_path():
     return "weaver-editor/icons"
-    
+


### PR DESCRIPTION
Got caught out by this during local dev when swapping branch 😅

This will ensure anyone can checkout any commit of GodotJS and building is just as simple as performing a regular Godot build. Granted, you do need `pnpm`, but aside from that, it's all automated. The `pnpm` commands were also only correct for Windows. I believe they'll now work on all platforms.

The JS builds are disabled by adding `skip_js_runtime=yes` to the scons build. CI now does this since CI prebuilds these just the once for all platforms.