### PR TITLE
feat: Implement reload scripts in GodotJSScriptLanguage.

### DIFF
--- a/weaver/jsb_script.h
+++ b/weaver/jsb_script.h
@@ -42,6 +42,12 @@ private:
      */
     jsb::StatelessScriptClassInfo script_class_info_;
 
+#ifdef DEBUG_ENABLED
+	HashMap<ObjectID, List<Pair<StringName, Variant>>> pending_reload_state_;
+#endif
+
+    friend class GodotJSScriptLanguage;
+
 private:
     void load_module_immediately();
     jsb_force_inline void ensure_module_loaded() const { if (jsb_unlikely(!loaded_)) const_cast<GodotJSScript*>(this)->load_module_immediately(); }
@@ -55,6 +61,8 @@ private:
 public:
     GodotJSScript();
     virtual ~GodotJSScript() override;
+
+	bool is_root_script() const { return get_base_script().is_null(); }
 
     StringName get_module_id() const { return script_class_info_.module_id; };
 

--- a/weaver/jsb_script_language.h
+++ b/weaver/jsb_script_language.h
@@ -260,6 +260,8 @@ public:
 private:
     std::shared_ptr<jsb::Environment> create_shadow_environment();
     void destroy_shadow_environment(const std::shared_ptr<jsb::Environment>& p_env);
+
+    void reload_scripts_internal(const Array& p_scripts, bool p_soft_reload);
 };
 
 #endif


### PR DESCRIPTION
Now we can modify, compile and focus in godot editor to trigger hot-reloading in debug process like GDScript.

NOTE: Callable that created by `Callable.create()` can't be reloaded.

---------

Edit:

https://github.com/user-attachments/assets/4e7dd8b7-c39c-4eb9-957e-6c5d65229ede

Test project:

[ts-reload-test.zip](https://github.com/user-attachments/files/24365528/ts-reload-test.zip)

