### PR TITLE
feat: Add ability to filter files for generating resources dts and scene dts.

### DIFF
--- a/.changeset/forty-dancers-obey.md
+++ b/.changeset/forty-dancers-obey.md
@@ -1,0 +1,5 @@
+---
+"@godot-js/editor": minor
+---
+
+feat: Add ability to filter files for generating resources dts and scene dts.

--- a/internal/jsb_settings.cpp
+++ b/internal/jsb_settings.cpp
@@ -38,6 +38,11 @@ namespace jsb::internal
     static constexpr char kRtPackagingIncludeDirectories[] = JSB_MODULE_NAME_STRING "/editor/packaging/include_directories";
     static constexpr char kRtPackagingReferencedNodeModules[] = JSB_MODULE_NAME_STRING "/editor/packaging/referenced_node_modules";
 
+    static constexpr char kRtResourceDTSIncludePathWildcards[] = JSB_MODULE_NAME_STRING "/codegen/resource_dts/include_path_wildcards";
+    static constexpr char kRtResourceDTSExcludePathWildcards[] = JSB_MODULE_NAME_STRING "/codegen/resource_dts/exclude_path_wildcards";
+    static constexpr char kRtSceneDTSIncludePathWildcards[] = JSB_MODULE_NAME_STRING "/codegen/scene_dts/include_path_wildcards";
+    static constexpr char kRtSceneDTSExcludePathWildcards[] = JSB_MODULE_NAME_STRING "/codegen/scene_dts/exclude_path_wildcards";
+
 #ifdef TOOLS_ENABLED
     bool init_editor_settings()
     {
@@ -124,6 +129,42 @@ namespace jsb::internal
             }
 
             _GLOBAL_DEF(kRtPackagingReferencedNodeModules, true, false);
+
+            {
+                PropertyInfo ResourceDTSIncludePathWildcards;
+                ResourceDTSIncludePathWildcards.type = Variant::PACKED_STRING_ARRAY;
+                ResourceDTSIncludePathWildcards.name = kRtResourceDTSIncludePathWildcards;
+                ResourceDTSIncludePathWildcards.hint = PROPERTY_HINT_ARRAY_TYPE;
+                ResourceDTSIncludePathWildcards.hint_string = vformat("%s/%s:", Variant::STRING, PROPERTY_HINT_DIR);
+                _GLOBAL_DEF(ResourceDTSIncludePathWildcards, PackedStringArray{"res://"}, false, JSB_SET_IGNORE_DOCS(false), JSB_SET_BASIC(true),  JSB_SET_INTERNAL(false));
+            }
+
+            {
+                PropertyInfo ResourceDTSExcludePathWildcards;
+                ResourceDTSExcludePathWildcards.type = Variant::PACKED_STRING_ARRAY;
+                ResourceDTSExcludePathWildcards.name = kRtResourceDTSExcludePathWildcards;
+                ResourceDTSExcludePathWildcards.hint = PROPERTY_HINT_ARRAY_TYPE;
+                ResourceDTSExcludePathWildcards.hint_string = vformat("%s/%s:", Variant::STRING, PROPERTY_HINT_DIR);
+                _GLOBAL_DEF(ResourceDTSExcludePathWildcards, PackedStringArray(), false, JSB_SET_IGNORE_DOCS(false), JSB_SET_BASIC(true),  JSB_SET_INTERNAL(false));
+            }
+
+            {
+                PropertyInfo SceneDTSIncludePathWildcards;
+                SceneDTSIncludePathWildcards.type = Variant::PACKED_STRING_ARRAY;
+                SceneDTSIncludePathWildcards.name = kRtSceneDTSIncludePathWildcards;
+                SceneDTSIncludePathWildcards.hint = PROPERTY_HINT_ARRAY_TYPE;
+                SceneDTSIncludePathWildcards.hint_string = vformat("%s/%s:", Variant::STRING, PROPERTY_HINT_DIR);
+                _GLOBAL_DEF(SceneDTSIncludePathWildcards, PackedStringArray{"res://"}, false, JSB_SET_IGNORE_DOCS(false), JSB_SET_BASIC(true),  JSB_SET_INTERNAL(false));
+            }
+
+            {
+                PropertyInfo SceneDTSExcludePathWildcards;
+                SceneDTSExcludePathWildcards.type = Variant::PACKED_STRING_ARRAY;
+                SceneDTSExcludePathWildcards.name = kRtSceneDTSExcludePathWildcards;
+                SceneDTSExcludePathWildcards.hint = PROPERTY_HINT_ARRAY_TYPE;
+                SceneDTSExcludePathWildcards.hint_string = vformat("%s/%s:", Variant::STRING, PROPERTY_HINT_DIR);
+                _GLOBAL_DEF(SceneDTSExcludePathWildcards, PackedStringArray(), false, JSB_SET_IGNORE_DOCS(false), JSB_SET_BASIC(true),  JSB_SET_INTERNAL(false));
+            }
         }
     }
 
@@ -200,6 +241,30 @@ namespace jsb::internal
     {
         init_settings();
         return GLOBAL_GET(kRtPackagingReferencedNodeModules);
+    }
+
+    PackedStringArray Settings::get_resource_dts_include_path_wildcards()
+    {
+        init_settings();
+        return (PackedStringArray) GLOBAL_GET(kRtResourceDTSIncludePathWildcards);
+    }
+
+    PackedStringArray Settings::get_resource_dts_exclude_path_wildcards()
+    {
+        init_settings();
+        return (PackedStringArray) GLOBAL_GET(kRtResourceDTSExcludePathWildcards);
+    }
+
+    PackedStringArray Settings::get_scene_dts_include_path_wildcards()
+    {
+        init_settings();
+        return (PackedStringArray) GLOBAL_GET(kRtSceneDTSIncludePathWildcards);
+    }
+
+    PackedStringArray Settings::get_scene_dts_exclude_path_wildcards()
+    {
+        init_settings();
+        return (PackedStringArray) GLOBAL_GET(kRtSceneDTSExcludePathWildcards);
     }
 
     uint16_t Settings::get_debugger_port()

--- a/internal/jsb_settings.h
+++ b/internal/jsb_settings.h
@@ -47,6 +47,11 @@ namespace jsb::internal
 
         static bool is_packaging_referenced_node_modules();
 
+        static PackedStringArray get_resource_dts_include_path_wildcards();
+        static PackedStringArray get_resource_dts_exclude_path_wildcards();
+        static PackedStringArray get_scene_dts_include_path_wildcards();
+        static PackedStringArray get_scene_dts_exclude_path_wildcards();
+
 #ifdef TOOLS_ENABLED
         // [EDITOR ONLY]
         static bool editor_settings_available();

--- a/weaver-editor/jsb_editor_plugin.h
+++ b/weaver-editor/jsb_editor_plugin.h
@@ -57,6 +57,9 @@ private:
     void _on_resource_saved(const Ref<Resource>& p_resource);
     void _generate_imported_resource_dts(const Vector<String>& p_resources);
 
+    static bool _is_path_matchn(const PackedStringArray& p_wildcards, const String& p_path);
+    static Vector<String> _filter_resource_paths(const PackedStringArray& p_exclude_wildcards, const PackedStringArray& p_include_wildcards, const Vector<String>& p_paths);
+
 protected:
     static void _bind_methods();
 


### PR DESCRIPTION
This pr add 4 project settings, to filter resource/scene for code generating, and keep it generate for all files by default.
<img width="1209" height="708" alt="image" src="https://github.com/user-attachments/assets/5aa52cbf-c9ca-4fd5-8c19-d7f05d5dce1b" />


The main purpose is to optimize the developing experience in large project, by reducing unecessary generated code.