### PR TITLE
feat: Implement Scene DTS generate strategic.

### DIFF
--- a/.changeset/loud-camels-sink.md
+++ b/.changeset/loud-camels-sink.md
@@ -1,0 +1,5 @@
+---
+"@godot-js/editor": minor
+---
+
+feat：Implement Scene DTS generate strategic.

--- a/internal/jsb_settings.cpp
+++ b/internal/jsb_settings.cpp
@@ -4,6 +4,11 @@
 #include "jsb_macros.h"
 #include "jsb_logger.h"
 
+#ifdef TOOLS_ENABLED
+#include "../weaver-editor/jsb_editor_helper.h"
+#include "core/templates/pair.h"
+#endif // TOOLS_ENABLED
+
 #define JSB_SET_RESTART(val) (val)
 #define JSB_SET_IGNORE_DOCS(val) (val)
 #define JSB_SET_BASIC(val) (val)
@@ -37,6 +42,8 @@ namespace jsb::internal
     static constexpr char kRtPackagingIncludeFiles[] = JSB_MODULE_NAME_STRING "/editor/packaging/include_files";
     static constexpr char kRtPackagingIncludeDirectories[] = JSB_MODULE_NAME_STRING "/editor/packaging/include_directories";
     static constexpr char kRtPackagingReferencedNodeModules[] = JSB_MODULE_NAME_STRING "/editor/packaging/referenced_node_modules";
+
+    static constexpr char kRtSceneDTSGenerateStrategic[] = JSB_MODULE_NAME_STRING "/codegen/scene_dts/generate_strategic";
 
 #ifdef TOOLS_ENABLED
     bool init_editor_settings()
@@ -124,6 +131,30 @@ namespace jsb::internal
             }
 
             _GLOBAL_DEF(kRtPackagingReferencedNodeModules, true, false);
+
+#ifdef TOOLS_ENABLED
+            {
+                PropertyInfo SceneDTSGenerateStrategic;
+                SceneDTSGenerateStrategic.type = Variant::INT;
+                SceneDTSGenerateStrategic.name = kRtSceneDTSGenerateStrategic;
+                SceneDTSGenerateStrategic.hint = PROPERTY_HINT_FLAGS;
+
+                // NOTE: Keep this map sync with GodotJSEditorHelper::SceneDTSGenerateStrategic
+                const LocalVector<Pair<String, GodotJSEditorHelper::SceneDTSGenerateStrategic>> scene_dts_generate_strategic_flags = {
+                    {"Origin Name Node", GodotJSEditorHelper::SCENE_DTS_GENERATE_STRATEGIC_ORIGIN_NAME_NODE},
+                    {"Unique Name Node", GodotJSEditorHelper::SCENE_DTS_GENERATE_STRATEGIC_UNIQUE_NAME_NODE}
+                };
+
+                Vector<String> flag_hints;
+                for (const auto &[name, value]: scene_dts_generate_strategic_flags)
+                {
+                    flag_hints.push_back(vformat("%s:%s", name, value));
+                }
+
+                SceneDTSGenerateStrategic.hint_string = String(",").join(flag_hints);
+                _GLOBAL_DEF(SceneDTSGenerateStrategic, BitField<GodotJSEditorHelper::SceneDTSGenerateStrategic>(GodotJSEditorHelper::SCENE_DTS_GENERATE_STRATEGIC_ORIGIN_NAME_NODE), false, JSB_SET_IGNORE_DOCS(false), JSB_SET_BASIC(true),  JSB_SET_INTERNAL(false));
+            }
+#endif // TOOLS_ENABLED
         }
     }
 
@@ -200,6 +231,12 @@ namespace jsb::internal
     {
         init_settings();
         return GLOBAL_GET(kRtPackagingReferencedNodeModules);
+    }
+
+    int Settings::get_scene_dts_generate_strategic()
+    {
+        init_settings();
+        return GLOBAL_GET(kRtSceneDTSGenerateStrategic);
     }
 
     uint16_t Settings::get_debugger_port()

--- a/internal/jsb_settings.h
+++ b/internal/jsb_settings.h
@@ -47,6 +47,8 @@ namespace jsb::internal
 
         static bool is_packaging_referenced_node_modules();
 
+        static int get_scene_dts_generate_strategic();
+
 #ifdef TOOLS_ENABLED
         // [EDITOR ONLY]
         static bool editor_settings_available();

--- a/weaver-editor/jsb_editor_helper.h
+++ b/weaver-editor/jsb_editor_helper.h
@@ -6,17 +6,24 @@ class GodotJSEditorHelper : public Object
 {
     GDCLASS(GodotJSEditorHelper, Object);
 
-private:
+public:
+    enum SceneDTSGenerateStrategic
+    {
+        SCENE_DTS_GENERATE_STRATEGIC_ORIGIN_NAME_NODE = 1 << 0,
+        SCENE_DTS_GENERATE_STRATEGIC_UNIQUE_NAME_NODE = 1 << 1,
+    };
 
+private:
     static bool _request_codegen(jsb::JSEnvironment& p_env, GodotJSScript* p_script, const Dictionary& p_request, Dictionary& p_result);
     static StringName _get_exposed_node_class_name(const StringName& class_name);
-    static Dictionary _build_node_type_descriptor(jsb::JSEnvironment& p_env, Node* p_node, const String& p_scene_resource_path = String());
+    static Dictionary _build_node_type_descriptor(const BitField<SceneDTSGenerateStrategic> p_strategic, jsb::JSEnvironment& p_env, Node* p_node, const Node* p_root_node, Dictionary& r_unique_name_nodes, const String& p_scene_resource_path = String());
     static void _log_load_error(const String &p_file, const String &p_type, Error p_error);
 
 protected:
     static void _bind_methods();
 
 public:
+
     virtual ~GodotJSEditorHelper() override = default;
 
     static Dictionary get_resource_type_descriptor(const String &p_path);
@@ -24,4 +31,5 @@ public:
     static void show_toast(const String& p_text, int p_severity);
 };
 
+VARIANT_BITFIELD_CAST(GodotJSEditorHelper::SceneDTSGenerateStrategic)
 #endif


### PR DESCRIPTION
Refer to my [comment in #175](https://github.com/godotjs/GodotJS/pull/175#issuecomment-3694974169).
This pr implement a project setting to control how to generate scene DTS:
<img width="1200" height="712" alt="image" src="https://github.com/user-attachments/assets/993a1897-fa71-46ef-a6ca-c0ec30a9eecf" />

This setting is BitField:
1. [√] Origin Name Node [×] Unique Name Node (default): Keep old behavior (generate full scene structure). 
<img width="370" height="305" alt="image" src="https://github.com/user-attachments/assets/3421b7f1-7631-4888-9908-dfd38f8cfc69" />

2. [×] Origin Name Node [√] Unique Name Node: Only unique name nodes will be generated (**without children info**).
<img width="355" height="227" alt="image" src="https://github.com/user-attachments/assets/40fb1b1b-74f0-4e63-8c3e-2cd4be51aec6" />

3. [√] Origin Name Node [√] Unique Name Node: Generate full scene structure, and append unique name nodes (**with children info**).
<img width="411" height="430" alt="image" src="https://github.com/user-attachments/assets/4ef0b736-7106-4cc5-81b0-b3de1ef877ca" />

5. [×] Origin Name Node [×] Unique Name Node: Will push a warning and fallback to case 1.


By use BitField, we can extends other strategics by adding new fields (for example, only detecting custom prefix/suffix).
The primary objective of this pr is to generate only the content that the user needs as much as possible.

-----------------------------------
Additionally, at ["weaver-editor/jsb_editor_helper.cpp:126"](https://github.com/Daylily-Zeleen/GodotJS/blob/7795fe0c64e972f7e6f8ecd21d26a6ac7ea30f59/weaver-editor/jsb_editor_helper.cpp#L126), I skip an unecessary case, parsing uneditable instance's children of packed scene, I'm not sure if this is appropriate.