### PR TITLE
fix: Fix decompressed bundled source use after free

### DIFF
--- a/weaver-editor/jsb_editor_plugin.cpp
+++ b/weaver-editor/jsb_editor_plugin.cpp
@@ -330,7 +330,8 @@ Error GodotJSEditorPlugin::apply_file(const jsb::weaver::InstallFileInfo &p_file
     }
     Error err;
     size_t size;
-    const char* data = get_preset_source(p_file.source_name).get_data(size);
+    jsb::internal::PresetSource preset = get_preset_source(p_file.source_name);
+    const char* data = preset.get_data(size);
     ERR_FAIL_COND_V_MSG(size == 0 || data == nullptr, ERR_FILE_NOT_FOUND, "bad data");
     err = DirAccess::make_dir_recursive_absolute(p_file.target_dir);
     ERR_FAIL_COND_V_MSG(err != OK, err, "failed to make dir");
@@ -396,7 +397,8 @@ bool GodotJSEditorPlugin::verify_file(const jsb::weaver::InstallFileInfo& p_file
     }
 
     size_t size;
-    const char* data = get_preset_source(p_file.source_name).get_data(size);
+    jsb::internal::PresetSource preset = get_preset_source(p_file.source_name);
+    const char* data = preset.get_data(size);
     if (size == 0 || data == nullptr) return false;
     const String target_name = jsb::internal::PathUtil::combine(p_file.target_dir, p_file.source_name);
     if (!FileAccess::exists(target_name)) return false;


### PR DESCRIPTION
This caused an intermittent failures e.g. https://github.com/godotjs/GodotJS/actions/runs/24649141103/job/72067918791.

I didn't review the history, but judging by how the code is written I suspect the data was not initially compressed, so the static data pointers were valid indefinitely (pointer to read-only load data in the executable). However, since the data is now decompressed, the data's lifetime is tied to lifetime of the `PresetSource`. It's stack allocated, so when it goes out of scope it's destroyed. Looks like we'd been getting lucky most of the time and nothing was writing to the now freed address range - but not so in that GHA run. Glad this was caught!