### PR TITLE
fix: enter V8 isolate/context scope before editor codegen compile

### DIFF
--- a/.changeset/editor-isolate-scope.md
+++ b/.changeset/editor-isolate-scope.md
@@ -1,0 +1,5 @@
+---
+"@godot-js/editor": patch
+---
+
+**Fix:** Enter the V8 isolate and context scopes before editor codegen compile to stop a SIGSEGV on batch reimport.

--- a/weaver-editor/jsb_editor_plugin.cpp
+++ b/weaver-editor/jsb_editor_plugin.cpp
@@ -856,9 +856,11 @@ try {
 
     std::shared_ptr<jsb::Environment> environment = lang->get_environment();
     v8::Isolate* isolate = environment->get_isolate();
+    v8::Isolate::Scope isolate_scope(isolate);
 
     v8::HandleScope handle_scope(isolate);
     v8::Local<v8::Context> context = environment->get_context();
+    v8::Context::Scope context_scope(context);
 
     v8::MaybeLocal<v8::Value> func_maybe = jsb::impl::Helper::compile_function(
         context, code, ::std::size(code) - 1, "generate_resource_type");
@@ -930,9 +932,11 @@ try {
 
     std::shared_ptr<jsb::Environment> environment = lang->get_environment();
     v8::Isolate* isolate = environment->get_isolate();
+    v8::Isolate::Scope isolate_scope(isolate);
 
     v8::HandleScope handle_scope(isolate);
     v8::Local<v8::Context> context = environment->get_context();
+    v8::Context::Scope context_scope(context);
 
     v8::MaybeLocal<v8::Value> func_maybe = jsb::impl::Helper::compile_function(
         context, code, ::std::size(code) - 1, "generate_resource_type");


### PR DESCRIPTION
**Problem**

When the editor builds the TypeScript type definitions for your project, it runs a small piece of JavaScript through the V8 engine to compile it. Before V8 can compile anything, the code has to "enter" the right V8 isolate and context — basically telling V8 which JavaScript world to work in.

Two of these code paths forgot that step: the one that builds types for scene nodes (`generate_scene_nodes_types`) and the one that builds types for resources (`generate_resource_types`). They entered only a `HandleScope`, not the `Isolate::Scope` and `Context::Scope`. The third path that does the same kind of work (`generate_types`) enters all three and works fine.

The result: on a cold start, or when you reimport a lot of files at once, the editor crashes (segfault) deep inside V8's compile step.

**What this changes**

Add the two missing scope guards (`v8::Isolate::Scope` and `v8::Context::Scope`) at both sites, in the same positions as the path that already works (`generate_types`): the `Isolate::Scope` alongside the existing `HandleScope`, and the `Context::Scope` before the compile call. No logic changes — it just adds two stack guards per site, using the same isolate and context the surrounding code already had.

**How to verify**

Rebuild the engine and trigger a batch reimport (or a cold editor start that regenerates types) to confirm the crash is gone.

A changeset is included.
