### PR TITLE
fix: serialize V8 isolate creation across threads

### DIFF
--- a/.changeset/serialize-isolate-creation.md
+++ b/.changeset/serialize-isolate-creation.md
@@ -1,0 +1,5 @@
+---
+"@godot-js/editor": patch
+---
+
+**Fix:** Serialize V8 platform init and isolate creation across threads so shadow/worker environments created concurrently no longer race V8's first-time lazy mutex init and crash.

--- a/bridge/jsb_environment.cpp
+++ b/bridge/jsb_environment.cpp
@@ -255,22 +255,34 @@ namespace jsb
         , object_db_(p_params.initial_object_slots)
     {
         JSB_BENCHMARK_SCOPE(JSEnvironment, Construct);
-        impl::GlobalInitialize::init();
-        v8::Isolate::CreateParams create_params;
-        create_params.array_buffer_allocator = &allocator_;
+
+        // Serialize V8 platform init + isolate creation across threads. The editor's
+        // resource loader constructs shadow Environments on worker threads (see
+        // GodotJSScriptLanguage::create_shadow_environment), concurrently with the main
+        // Environment and with each other. Unsynchronized v8::Isolate::New races V8's
+        // first-time lazy global initialization and crashes (SIGSEGV deep in
+        // v8::base::LazyInstanceImpl<Mutex>::InitInstance) on optimized builds.
+        static Mutex isolate_creation_mutex;
+        {
+            MutexLock isolate_creation_lock(isolate_creation_mutex);
+
+            impl::GlobalInitialize::init();
+            v8::Isolate::CreateParams create_params;
+            create_params.array_buffer_allocator = &allocator_;
 #if JSB_V8_CPPGC
-        // old version:
-        cpp_heap_ = v8::CppHeap::Create(impl::GlobalInitialize::get_platform(),
-            v8::CppHeapCreateParams({}, v8::WrapperDescriptor(kWrapperTypeIndex, kWrapperInstanceIndex, kWrapperID)));
-        // new version:
-        // cpp_heap_ = v8::CppHeap::Create(impl::GlobalInitialize::get_platform(), v8::CppHeapCreateParams({}));
-        create_params.cpp_heap = cpp_heap_.get();
+            // old version:
+            cpp_heap_ = v8::CppHeap::Create(impl::GlobalInitialize::get_platform(),
+                v8::CppHeapCreateParams({}, v8::WrapperDescriptor(kWrapperTypeIndex, kWrapperInstanceIndex, kWrapperID)));
+            // new version:
+            // cpp_heap_ = v8::CppHeap::Create(impl::GlobalInitialize::get_platform(), v8::CppHeapCreateParams({}));
+            create_params.cpp_heap = cpp_heap_.get();
 #endif
 
-        if (p_params.type == Type::Worker) flags_ |= EF_Worker;
-        else if (p_params.type == Type::Shadow) flags_ |= EF_Shadow;
+            if (p_params.type == Type::Worker) flags_ |= EF_Worker;
+            else if (p_params.type == Type::Shadow) flags_ |= EF_Shadow;
 
-        isolate_ = v8::Isolate::New(create_params);
+            isolate_ = v8::Isolate::New(create_params);
+        }
         isolate_->SetData(kIsolateEmbedderData, this);
         isolate_->SetPromiseRejectCallback(PromiseRejectCallback_);
 #if JSB_PRINT_GC_TIME


### PR DESCRIPTION
**Problem**

GodotJS can start extra V8 "environments" on background threads. For example, the editor's resource loader creates short-lived, pooled "shadow" environments on worker threads while the main environment is also starting up.

The first `v8::Isolate::New` call in a process triggers one-time initialization *inside V8* that is not thread-safe. (GodotJS's own `GlobalInitialize::init()` is already a thread-safe magic static; the race is V8-internal, kicked off by the first concurrent isolate creations.) So when several environments create isolates at the same moment on different threads, they race through that lazy init and the engine crashes (segfault) deep inside V8 (in `LazyInstanceImpl<Mutex>::InitInstance`, on optimized builds).

**What this changes**

Put a single process-wide lock around the first-time V8 setup and the isolate creation in the `Environment` constructor (`bridge/jsb_environment.cpp`), so only one thread runs that block at a time. Everything after it (setting callbacks, creating the context, and so on) stays outside the lock and runs normally.

The lock is one function-local `static` mutex, which means every thread shares the same single lock — that's what makes the protection process-wide instead of per-environment. Most of the diff is just re-indentation from wrapping the block.

**How to verify**

Rebuild the engine and stress concurrent environment creation — for example a batch reimport that spawns shadow environments on worker threads — and confirm it no longer crashes on startup.

A changeset is included.
