### PR TITLE
fix: scan_external_changes never reloads script-bearing modules

### DIFF
--- a/.changeset/hot-reload-script-modules.md
+++ b/.changeset/hot-reload-script-modules.md
@@ -1,0 +1,5 @@
+---
+"@godot-js/editor": patch
+---
+
+**Fix:** Editing a script on disk now reloads script-bearing modules and rebinds live `GodotJSScript` instances. `scan_external_changes()` no longer skips script modules, cascades the reload through transitive dependents, and resets `module.exports` so ES-module-style default exports survive a second run.

--- a/bridge/jsb_bridge_module_loader.cpp
+++ b/bridge/jsb_bridge_module_loader.cpp
@@ -3,6 +3,7 @@
 #include "jsb_editor_utility_funcs.h"
 #include "jsb_callable.h"
 #include "jsb_object_bindings.h"
+#include "../weaver/jsb_script_language.h"
 
 namespace jsb
 {
@@ -480,6 +481,28 @@ namespace jsb
             }
         }
 
+        // function scan_external_changes(): void
+        // Re-scan loaded modules, reloading any whose mtime + hash drifted since last load.
+        // Mirrors the editor's app-focus-driven scan so headless tests (and other non-editor
+        // callers) can drive a reload without an EditorFileSystem.
+        void _scan_external_changes(const v8::FunctionCallbackInfo<v8::Value>& info)
+        {
+            Environment* env = Environment::wrap(info.GetIsolate());
+            jsb_check(env);
+            // Prefer the language wrapper so script-bearing modules get their
+            // live instances rebound after the env reload. Fall back to env
+            // alone if the language singleton isn't initialised (unusual,
+            // headless-jsb-only builds).
+            if (GodotJSScriptLanguage* lang = GodotJSScriptLanguage::get_singleton())
+            {
+                lang->scan_external_changes();
+            }
+            else
+            {
+                (void) env->scan_external_changes();
+            }
+        }
+
         void _add_module(const v8::FunctionCallbackInfo<v8::Value>& info)
         {
             v8::Isolate* isolate = info.GetIsolate();
@@ -596,6 +619,7 @@ namespace jsb
 
                 internal_obj->Set(context, impl::Helper::new_string_ascii(isolate, "find_module"), JSB_NEW_FUNCTION(context, _find_module, {})).Check();
                 internal_obj->Set(context, impl::Helper::new_string_ascii(isolate, "add_module"), JSB_NEW_FUNCTION(context, _add_module, {})).Check();
+                internal_obj->Set(context, impl::Helper::new_string_ascii(isolate, "scan_external_changes"), JSB_NEW_FUNCTION(context, _scan_external_changes, {})).Check();
 
                 internal_obj->Set(context, impl::Helper::new_string_ascii(isolate, "add_script_signal"), JSB_NEW_FUNCTION(context, _add_script_signal, {})).Check();
                 internal_obj->Set(context, impl::Helper::new_string_ascii(isolate, "add_script_property"), JSB_NEW_FUNCTION(context, _add_script_property, {})).Check();

--- a/bridge/jsb_environment.cpp
+++ b/bridge/jsb_environment.cpp
@@ -1089,26 +1089,83 @@ namespace jsb
         return new_id;
     }
 
-    void Environment::scan_external_changes()
+    Vector<StringName> Environment::scan_external_changes()
     {
         check_internal_state();
+        v8::Isolate* isolate = isolate_;
+        v8::Isolate::Scope isolate_scope(isolate);
+        v8::HandleScope handle_scope(isolate);
+        v8::Local<v8::Context> context = context_.Get(isolate);
+        v8::Context::Scope context_scope(context);
+
         Vector<StringName> requested_modules;
+        HashSet<StringName> dirty_set;
         for (const KeyValue<StringName, JavaScriptModule*>& kv : module_cache_.modules_)
         {
             JavaScriptModule* module = kv.value;
-            // skip script modules which are managed by the godot editor
-            if (module->script_class_id) continue;
+            // Script-bearing modules are no longer skipped. The reload path
+            // inside _load_module already handles re-execution and
+            // ScriptClassInfo::_parse_script_class; GodotJSScriptLanguage
+            // uses the returned ids to rebind live instances.
             if (module->mark_as_reloading())
             {
+                JSB_LOG(Verbose, "[reload] marked dirty: %s (is_script=%d)", module->id, (int)(bool)module->script_class_id);
                 requested_modules.append(module->id);
+                dirty_set.insert(module->id);
+            }
+        }
+
+        // Transitive invalidation: any module whose `children` array contains
+        // a dirty module is also dirty. Fixed-point iterate over the module
+        // graph. `children` is the v8 Array built during initial load (see the
+        // jsb_name(this, children) Set in _load_module); each entry is another
+        // module object with an `id` property.
+        const v8::Local<v8::Name> children_name = jsb_name(this, children);
+        const v8::Local<v8::Name> id_name = jsb_name(this, id);
+        bool changed = true;
+        while (changed)
+        {
+            changed = false;
+            for (const KeyValue<StringName, JavaScriptModule*>& kv : module_cache_.modules_)
+            {
+                JavaScriptModule* module = kv.value;
+                if (dirty_set.has(module->id)) continue;
+                const v8::Local<v8::Object> module_obj = module->module.Get(isolate);
+                v8::Local<v8::Value> children_val;
+                if (!module_obj->Get(context, children_name).ToLocal(&children_val) || !children_val->IsArray()) continue;
+                const v8::Local<v8::Array> children = children_val.As<v8::Array>();
+                const uint32_t count = children->Length();
+                bool depends_on_dirty = false;
+                for (uint32_t i = 0; i < count; i++)
+                {
+                    v8::Local<v8::Value> child_val;
+                    if (!children->Get(context, i).ToLocal(&child_val) || !child_val->IsObject()) continue;
+                    v8::Local<v8::Value> child_id_val;
+                    if (!child_val.As<v8::Object>()->Get(context, id_name).ToLocal(&child_id_val) || !child_id_val->IsString()) continue;
+                    const String child_id_str = impl::Helper::to_string(isolate, child_id_val);
+                    if (dirty_set.has(StringName(child_id_str)))
+                    {
+                        depends_on_dirty = true;
+                        break;
+                    }
+                }
+                if (depends_on_dirty)
+                {
+                    JSB_LOG(Verbose, "[reload] cascaded dirty: %s (depends on a dirty module)", module->id);
+                    module->force_mark_as_reloading();
+                    requested_modules.append(module->id);
+                    dirty_set.insert(module->id);
+                    changed = true;
+                }
             }
         }
 
         for (const StringName& id : requested_modules)
         {
-            JSB_LOG(Verbose, "changed module check: %s", id);
+            JSB_LOG(Verbose, "[reload] reloading via load(): %s", id);
             load(id);
         }
+        return requested_modules;
     }
 
     ModuleReloadResult::Type Environment::mark_as_reloading(const StringName& p_name)
@@ -1242,6 +1299,20 @@ namespace jsb
 
                     JSB_LOG(VeryVerbose, "reload module %s", module_id);
                     resolved_module->mark_as_reloaded();
+
+                    // Reset `exports` to a fresh Object before re-running the
+                    // wrapped source. Compilers targeting CJS for ES `export default`
+                    // emit `Object.defineProperty(exports, "default", { configurable: false, ... })`,
+                    // which throws "Cannot redefine property" on the second run
+                    // when the OLD non-configurable "default" still sits on
+                    // exports. Without this reset, the reload silently fails
+                    // for any module using ES-module-style default exports.
+                    {
+                        v8::Local<v8::Object> fresh_exports = v8::Object::New(isolate);
+                        const v8::Local<v8::Object> module_obj_local = resolved_module->module.Get(isolate);
+                        module_obj_local->Set(context, jsb_name(this, exports), fresh_exports).Check();
+                        resolved_module->exports.Reset(isolate, fresh_exports);
+                    }
                     if (!resolver->load(this, source_info.source_filepath, *resolved_module))
                     {
                         return nullptr;

--- a/bridge/jsb_environment.h
+++ b/bridge/jsb_environment.h
@@ -399,9 +399,11 @@ namespace jsb
         JavaScriptModule* _load_module(const String& p_parent_id, const String& p_module_id);
 
         // manually scan changes of modules,
-        // will reload IMMEDIATELY
-        // (modules not attached with GodotJS script are not automatically reloaded by resource manager)
-        void scan_external_changes();
+        // will reload IMMEDIATELY and return the list of module ids whose
+        // sources changed on disk and were re-executed. Script-bearing modules
+        // are included; callers can use the list to rebind live GodotJSScript
+        // instances.
+        Vector<StringName> scan_external_changes();
 
         // request to reload a module,
         // will reload until next load.

--- a/bridge/jsb_module.cpp
+++ b/bridge/jsb_module.cpp
@@ -46,6 +46,21 @@ namespace jsb
 #endif
     }
 
+    void JavaScriptModule::force_mark_as_reloading()
+    {
+#if JSB_SUPPORT_RELOAD && defined(TOOLS_ENABLED)
+        // Bypass the mtime/md5 gate — used by transitive invalidation when a
+        // dependency reloaded but our own source bytes didn't change. Bumping
+        // time_modified to the current disk mtime keeps the cache coherent
+        // with the next mark_as_reloading() probe.
+        if (is_reloadable())
+        {
+            time_modified = FileAccess::get_modified_time(source_info.source_filepath);
+        }
+        reload_requested = true;
+#endif
+    }
+
     JavaScriptModule& JavaScriptModuleCache::insert(v8::Isolate* isolate, const v8::Local<v8::Context>& context, const StringName& p_name, bool p_main_candidate, bool p_init_loaded)
     {
         jsb_checkf(!((String) p_name).is_empty(), "empty module name is not allowed");

--- a/bridge/jsb_module.h
+++ b/bridge/jsb_module.h
@@ -58,6 +58,11 @@ namespace jsb
         bool mark_as_reloading();
         void mark_as_reloaded();
 
+        // Force reload even when mtime/md5 haven't changed (transitive
+        // invalidation cascades dependent modules). Safe to call any time;
+        // matches mark_as_reloaded()'s reset semantics for hash/time fields.
+        void force_mark_as_reloading();
+
     };
 
     struct JavaScriptModuleCache

--- a/tests/project/tests/reload/Reload.tscn
+++ b/tests/project/tests/reload/Reload.tscn
@@ -1,0 +1,11 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://tests/reload/test-reload.ts" id="1_rl1ad"]
+
+[node name="Reload" type="Node2D"]
+script = ExtResource("1_rl1ad")
+
+[node name="Label" type="Label" parent="."]
+offset_right = 40.0
+offset_bottom = 23.0
+text = "Reload"

--- a/tests/project/tests/reload/ScriptClassReload.tscn
+++ b/tests/project/tests/reload/ScriptClassReload.tscn
@@ -1,0 +1,11 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://tests/reload/test-script-class-reload.ts" id="1_scrl1"]
+
+[node name="ScriptClassReload" type="Node2D"]
+script = ExtResource("1_scrl1")
+
+[node name="Label" type="Label" parent="."]
+offset_right = 40.0
+offset_bottom = 23.0
+text = "ScriptClassReload"

--- a/tests/project/tests/reload/script-class-target.js
+++ b/tests/project/tests/reload/script-class-target.js
@@ -1,0 +1,14 @@
+const godot = require("godot");
+
+class ScriptClassTarget extends godot.Node {
+    getValue() {
+        return 1;
+    }
+}
+
+Object.defineProperty(module.exports, "default", {
+    configurable: false,
+    enumerable: true,
+    writable: false,
+    value: ScriptClassTarget,
+});

--- a/tests/project/tests/reload/target.js
+++ b/tests/project/tests/reload/target.js
@@ -1,0 +1,1 @@
+module.exports = { getValue: () => 1 };

--- a/tests/project/tests/reload/test-reload.ts
+++ b/tests/project/tests/reload/test-reload.ts
@@ -1,0 +1,58 @@
+import { FileAccess, Node } from "godot";
+import { beginAsyncTest, endAsyncTest, reportTestFailure } from "../test-status";
+
+declare function require(id: string): any;
+
+const jsb = require("godot-jsb") as { internal: { scan_external_changes: () => void } };
+
+const TARGET_PATH = "res://tests/reload/target.js";
+
+async function runReloadTest(): Promise<void> {
+    const reader = FileAccess.open(TARGET_PATH, FileAccess.ModeFlags.READ);
+    if (!reader) throw new Error("failed to open target.js for read");
+    const original = reader.get_as_text();
+    reader.close();
+
+    try {
+        const initial = require("./target");
+        const initialValue = initial.getValue();
+        if (initialValue !== 1) {
+            throw new Error(`expected initial value 1, got ${initialValue}`);
+        }
+
+        // FileAccess::get_modified_time is 1-second-granular on most platforms;
+        // wait so mark_as_reloading() sees a distinct mtime on the second write.
+        await new Promise<void>((resolve) => setTimeout(resolve, 1100));
+
+        const writer = FileAccess.open(TARGET_PATH, FileAccess.ModeFlags.WRITE);
+        if (!writer) throw new Error("failed to open target.js for write");
+        writer.store_string("module.exports = { getValue: () => 2 };\n");
+        writer.close();
+
+        const t0 = Date.now();
+        jsb.internal.scan_external_changes();
+        const reloaded = require("./target");
+        const elapsed = Date.now() - t0;
+
+        const newValue = reloaded.getValue();
+        if (newValue !== 2) {
+            throw new Error(`expected reloaded value 2, got ${newValue}`);
+        }
+        console.log(`TestReload: module hot reload OK (${elapsed}ms)`);
+    } finally {
+        const restorer = FileAccess.open(TARGET_PATH, FileAccess.ModeFlags.WRITE);
+        if (restorer) {
+            restorer.store_string(original);
+            restorer.close();
+        }
+    }
+}
+
+export default class TestReload extends Node {
+    _ready(): void {
+        beginAsyncTest();
+        runReloadTest()
+            .catch((error) => reportTestFailure("reload", error))
+            .finally(() => endAsyncTest());
+    }
+}

--- a/tests/project/tests/reload/test-script-class-reload.ts
+++ b/tests/project/tests/reload/test-script-class-reload.ts
@@ -1,0 +1,118 @@
+import { FileAccess, Node } from "godot";
+import { beginAsyncTest, endAsyncTest, reportTestFailure } from "../test-status";
+
+declare function require(id: string): any;
+
+const jsb = require("godot-jsb") as { internal: { scan_external_changes: () => void } };
+
+const SCRIPT_PATH = "res://tests/reload/script-class-target.js";
+const BASE_PATH = "res://tests/reload/transitive-base.js";
+
+function readFile(path: string): string {
+    const reader = FileAccess.open(path, FileAccess.ModeFlags.READ);
+    if (!reader) throw new Error(`failed to open ${path} for read`);
+    const s = reader.get_as_text();
+    reader.close();
+    return s;
+}
+
+function writeFile(path: string, content: string): void {
+    const writer = FileAccess.open(path, FileAccess.ModeFlags.WRITE);
+    if (!writer) throw new Error(`failed to open ${path} for write`);
+    writer.store_string(content);
+    writer.close();
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Verifies the fix for the `Object.defineProperty(exports, "default", { configurable: false, ... })`
+// trap: re-running a reloaded module that uses ES `export default` (or its CJS
+// equivalent emitted by tsc/swc/esbuild) would throw "Cannot redefine property:
+// default" on the second run; before the env-side `exports` reset, the engine
+// swallowed the exception and the class identity (and prototype) stayed pinned
+// at the pre-reload class.
+async function runDirectScriptClassReloadTest(): Promise<void> {
+    const original = readFile(SCRIPT_PATH);
+    try {
+        const before = require("./script-class-target");
+        const beforeProto = before?.default?.prototype;
+        if (typeof beforeProto?.getValue !== "function") {
+            throw new Error("baseline: getValue() not found on prototype");
+        }
+
+        // FileAccess::get_modified_time is 1-second-granular on most platforms.
+        await sleep(1100);
+        const mutated = original
+            .replace("return 1;", "return 2;\n    }\n    getSentinel() { return \"hot-reload-ok\"; ");
+        if (mutated === original) throw new Error("mutation produced no diff");
+        writeFile(SCRIPT_PATH, mutated);
+
+        jsb.internal.scan_external_changes();
+
+        const after = require("./script-class-target");
+        const afterProto = after?.default?.prototype;
+        if (typeof afterProto?.getSentinel !== "function") {
+            throw new Error(
+                "post-reload: new getSentinel() method missing from prototype — exports.default did not pick up the reloaded class (likely the defineProperty trap)",
+            );
+        }
+        const sentinelValue = afterProto.getSentinel.call(null);
+        if (sentinelValue !== "hot-reload-ok") {
+            throw new Error(`post-reload: getSentinel() returned ${JSON.stringify(sentinelValue)} (expected "hot-reload-ok")`);
+        }
+        console.log("TestScriptClassReload: direct-reload OK");
+    } finally {
+        writeFile(SCRIPT_PATH, original);
+        await sleep(1100);
+        jsb.internal.scan_external_changes();
+    }
+}
+
+// Verifies the transitive cascade: when an imported dependency reloads, any
+// module whose `children` array contains the dirty module is also re-executed
+// so its top-level closures (and any class declarations that depend on the
+// imported values) pick up the new module state.
+async function runTransitiveReloadTest(): Promise<void> {
+    const baseOriginal = readFile(BASE_PATH);
+    try {
+        const beforeDep = require("./transitive-dependent");
+        const beforeCombined = beforeDep?.default?.prototype?.getCombined?.call(null);
+        if (beforeCombined !== 11) {
+            throw new Error(`baseline: getCombined() returned ${beforeCombined} (expected 11)`);
+        }
+
+        await sleep(1100);
+        const baseMutated = baseOriginal.replace("return 10;", "return 100;");
+        if (baseMutated === baseOriginal) throw new Error("base mutation produced no diff");
+        writeFile(BASE_PATH, baseMutated);
+
+        jsb.internal.scan_external_changes();
+
+        const afterDep = require("./transitive-dependent");
+        const afterCombined = afterDep?.default?.prototype?.getCombined?.call(null);
+        if (afterCombined !== 101) {
+            throw new Error(
+                `post-cascade: getCombined() returned ${afterCombined} (expected 101 — the dependent module did not transitively reload after its base changed)`,
+            );
+        }
+        console.log("TestScriptClassReload: transitive-reload OK");
+    } finally {
+        writeFile(BASE_PATH, baseOriginal);
+        await sleep(1100);
+        jsb.internal.scan_external_changes();
+    }
+}
+
+export default class TestScriptClassReload extends Node {
+    _ready(): void {
+        beginAsyncTest();
+        (async () => {
+            await runDirectScriptClassReloadTest();
+            await runTransitiveReloadTest();
+        })()
+            .catch((error) => reportTestFailure("script-class-reload", error))
+            .finally(() => endAsyncTest());
+    }
+}

--- a/tests/project/tests/reload/transitive-base.js
+++ b/tests/project/tests/reload/transitive-base.js
@@ -1,0 +1,3 @@
+module.exports.baseValue = function baseValue() {
+    return 10;
+};

--- a/tests/project/tests/reload/transitive-dependent.js
+++ b/tests/project/tests/reload/transitive-dependent.js
@@ -1,0 +1,10 @@
+const godot = require("godot");
+const base = require("./transitive-base");
+
+class TransitiveDependent extends godot.Node {
+    getCombined() {
+        return base.baseValue() + 1;
+    }
+}
+
+module.exports.default = TransitiveDependent;

--- a/tests/project/tests/start.ts
+++ b/tests/project/tests/start.ts
@@ -21,6 +21,8 @@ export default class Start extends Node {
                 "res://tests/papaparse/Papaparse.tscn",
                 "res://tests/os-executor/OSExecutor.tscn",
                 "res://tests/worker/Worker.tscn",
+                "res://tests/reload/Reload.tscn",
+                "res://tests/reload/ScriptClassReload.tscn",
             ];
 
             for (const scene of scenes) {

--- a/weaver/jsb_script.cpp
+++ b/weaver/jsb_script.cpp
@@ -609,6 +609,26 @@ void GodotJSScript::load_module_immediately()
     JSB_LOG(Debug, "a stub script loaded which does not contain a GodotJS class %s", path);
 }
 
+void GodotJSScript::force_reload_for_scan()
+{
+    JSB_LOG(Verbose, "[reload] force_reload_for_scan %s loaded=%d valid=%d", get_path(), (int)loaded_, (int)_is_valid());
+    // No live module yet — nothing to rebind. Next access will trigger
+    // ensure_module_loaded() and pick up whatever the env scan loaded.
+    if (!loaded_) return;
+    if (!_is_valid()) return;
+
+    // Drop loaded_ so load_module_immediately re-runs the rebind loop. The
+    // env scan already re-executed any dirty sources, so this is mostly a
+    // prototype refresh against the env's freshly-evaluated module object.
+    loaded_ = false;
+    load_module_immediately();
+
+    // Tell anyone watching the script that exports / methods may have changed
+    // (editor inspector, scene tree, doc tools).
+    emit_changed();
+    update_exports();
+}
+
 PlaceHolderScriptInstance* GodotJSScript::placeholder_instance_create(Object* p_this)
 {
 #ifdef TOOLS_ENABLED

--- a/weaver/jsb_script.h
+++ b/weaver/jsb_script.h
@@ -62,6 +62,14 @@ public:
     Error load_source_code(const String &p_path);
     void load_module_if_missing();
 
+    // Called by GodotJSScriptLanguage::scan_external_changes() when env detected
+    // any module reload. Re-fetches the module from env (which holds the new
+    // exports), updates script_class_info_, and rebinds live instances via the
+    // existing load_module_immediately() rebind loop. Emits Script::changed so
+    // the editor inspector + scene tree pick up new exported properties without
+    // a manual click-off/click-on.
+    void force_reload_for_scan();
+
     // Creates a ScriptInstance (for an existing Godot native object) and associates the ScriptInstance with an existing JS object (instance of the script's JS class).
     ScriptInstance* instance_create(const v8::Local<v8::Object>& p_this, Object* p_owner, bool p_is_temp_allowed);
 

--- a/weaver/jsb_script_language.cpp
+++ b/weaver/jsb_script_language.cpp
@@ -414,20 +414,50 @@ String GodotJSScriptLanguage::get_type() const
 
 void GodotJSScriptLanguage::scan_external_changes()
 {
-    environment_->scan_external_changes();
+    const Vector<StringName> reloaded = environment_->scan_external_changes();
 
-#ifdef TOOLS_ENABLED
-    // fix scripts with no .js counterpart found (only missing scripts)
+    // Build a set of reloaded module ids so we can narrow the rebind set to
+    // only the scripts whose module (or one of its transitive dependencies)
+    // actually changed. env's scan body already cascaded dirty marks through
+    // the children graph (see jsb_environment.cpp), so any script that needs
+    // a fresh prototype is in this set.
+    HashSet<StringName> reloaded_set;
+    for (const StringName& id : reloaded) reloaded_set.insert(id);
+
+    // Snapshot script_list_ into Refs under the lock, then iterate the snapshot
+    // instead of the live list. mutex_ is a recursive Mutex (Godot's Mutex wraps
+    // std::recursive_mutex), so re-entering it from the rebind path is not a
+    // self-deadlock. The hazard is iterator invalidation / use-after-free:
+    // force_reload_for_scan -> set_script(Ref<Script>()) can drop the last ref
+    // to a GodotJSScript, and ~GodotJSScript calls script_list_.remove_from_list()
+    // under this same recursive lock, mutating script_list_ mid-iteration. Holding
+    // a Ref per element keeps each script alive across the loop and decouples our
+    // traversal from concurrent list mutation; the language owns this list.
+    Vector<Ref<GodotJSScript>> snapshot;
     {
         MutexLock lock(mutex_);
         const SelfList<GodotJSScript>* elem = script_list_.first();
         while (elem)
         {
-            elem->self()->load_module_if_missing();
+            snapshot.push_back(Ref<GodotJSScript>(elem->self()));
             elem = elem->next();
         }
     }
+
+    for (const Ref<GodotJSScript>& script : snapshot)
+    {
+#ifdef TOOLS_ENABLED
+        // editor-only safety net (runs every scan, as before): a script whose
+        // .js counterpart was missing at load gets re-attached once it appears
+        script->load_module_if_missing();
 #endif
+        if (reloaded_set.has(script->get_module_id()))
+        {
+            // Inspector refresh: force_reload_for_scan emits the standard
+            // Script::changed signal which the editor inspector listens to.
+            script->force_reload_for_scan();
+        }
+    }
 }
 
 void GodotJSScriptLanguage::thread_enter()


### PR DESCRIPTION
**Problem**

When you edit a script file on disk — a `.ts` or `.js` that defines a Godot class — and switch back to the editor, GodotJS should notice the change and reload it so your running scene picks up the new code. It didn't.

Two things were in the way:

- `Environment::scan_external_changes()` deliberately skipped any module that was a script (there was a `// skip script modules which are managed by the godot editor` line), so a script edit never reached the reload path.
- The other reload entry point, `GodotJSScriptLanguage::reload_tool_script()`, is an empty stub.

So editing a script class on disk never reloaded it — even though the underlying reload machinery (re-running the module and re-parsing the class) mostly already worked (modulo the `exports`-redefinition trap fixed below).

**What this changes**

- **Stop skipping script modules** in the scan, and have `scan_external_changes()` return the list of module ids it reloaded.
- **Cascade to dependents.** If module A changed and module B imports A, B reloads too. This walks the existing import graph until nothing new needs reloading.
- **Reset `module.exports` before re-running.** When `swc` or `esbuild` targets CommonJS for an `export default`, they emit `Object.defineProperty(exports, "default", { enumerable: true, get: ... })` with `configurable` defaulting to `false`; on the second run that throws `Cannot redefine property: default`. (`tsc` emits a plain `exports.default = X` for default exports, but hits the same non-configurable trap via the `__createBinding` helper when re-exporting — `export { x } from './y'`.) Resetting `exports` to a fresh object before re-running the module avoids the trap for any compiler.
- **Rebind only what changed.** After reload, live `GodotJSScript` instances are rebound — but only the ones whose module is in the reloaded ("dirty") set, not every script. The editor-only recovery pass (re-attaching a script whose `.js` was missing at load) still runs on every scan, as before. The rebind snapshots the script list under the lock and iterates the snapshot, because a reload can drop a script and modify that list mid-walk.

**Tests**

New tests under `tests/project/tests/reload/`:

- a direct module reload,
- a script-class default-export reload (covers the `Cannot redefine property` case),
- a transitive cascade (edit a base module, confirm a dependent's class picks up the change).

They use plain `.js` fixtures, so they reproduce the bugs without needing any TypeScript transpiler. To drive the scan headlessly the tests call a small new internal binding, `jsb.internal.scan_external_changes()` (added in the bridge module loader), which routes through the language singleton so the rebind path is exercised too.

**Known follow-ups (not in this PR)**

- The rebind loop is main-thread-only; reloading a script that has worker-thread instances would be unsafe and should get a main-thread guard.
- The canonical `reload_tool_script()` entry point is still a stub. Now that the scan path works, wiring it up is a reasonable separate change.
- A few `Verbose`-level `[reload]` diagnostic logs remain and could be trimmed.

**How to verify**

Rebuild the engine, then in the editor edit a script that defines an exported class, switch focus back to the editor, and confirm the running scene and the inspector pick up the change (including new `@export` properties) without a manual reload.

A changeset is included.
