### PR TITLE
fix: prefer search paths over parent-relative node_modules walk

### DIFF
--- a/.changeset/resolver-search-path-first.md
+++ b/.changeset/resolver-search-path-first.md
@@ -1,0 +1,5 @@
+---
+"@godot-js/editor": patch
+---
+
+**Fix:** Bare module specifiers now resolve against configured search paths before the parent-relative `node_modules` walk, so curated pre-bundled deps in `.godot/GodotJS/<dep>.js` win over raw CJS reached via the symlink chain.

--- a/bridge/jsb_environment.cpp
+++ b/bridge/jsb_environment.cpp
@@ -1176,11 +1176,15 @@ namespace jsb
 
         // init source module
         ModuleSourceInfo source_info;
-        IModuleResolver* resolver = nullptr;
+        IModuleResolver* resolver = this->find_module_resolver(normalized_id, source_info);
 
-        // Resolve bare specifiers against parent-relative node_modules chains first.
-        // This mirrors Node-like lookup and supports non-hoisted pnpm/yarn layouts.
-        if (!is_relative_module_id && !is_absolute_module_id && p_parent_id.begins_with("res://"))
+        // Fall back to parent-relative node_modules chains for bare specifiers
+        // when search paths missed. Mirrors Node-like lookup and supports
+        // non-hoisted pnpm/yarn layouts. Search paths win first so curated
+        // pre-bundled deps in `.godot/GodotJS/<dep>.js` (which Bun processed
+        // to drop `process.env.NODE_ENV` etc.) take precedence over the raw
+        // CJS in `node_modules/<dep>/dist/...` reached via Bun's symlink chain.
+        if (!resolver && !is_relative_module_id && !is_absolute_module_id && p_parent_id.begins_with("res://"))
         {
             auto get_parent_lookup_dir = [](const String& p_dir) -> String
             {
@@ -1215,12 +1219,6 @@ namespace jsb
                     break;
                 }
             }
-
-        }
-
-        if (!resolver)
-        {
-            resolver = this->find_module_resolver(normalized_id, source_info);
         }
 
         if (resolver)


### PR DESCRIPTION
**Problem**

When your code imports a bare package name — like `require("immer")` — GodotJS has to figure out which file that means. It has two ways to look:

1. The configured **search paths** (for example `res://.godot/GodotJS/`), where clean, pre-bundled copies of dependencies live.
2. A **`node_modules` walk** up the folder tree, the way Node.js resolves packages. With Bun/pnpm symlinks, this lands on the raw npm package.

The old code tried the `node_modules` walk **first**. So `require("immer")` found the raw npm file `node_modules/immer/dist/cjs/index.js`, whose first real statement checks `process.env.NODE_ENV`. There is no `process` in the GodotJS runtime, so it broke. The clean pre-bundled copy at `.godot/GodotJS/immer.js` (which Bun had already processed to strip out the `process` references) was sitting right there on a search path, but it never got the chance to win.

**What this changes**

Flip the order: try the search paths first, and only fall back to the parent-relative `node_modules` walk if the search paths don't have the module. Note that `res://node_modules` is itself the last configured search path, so a hoisted root `node_modules` package still resolves when no curated bundle exists; the parent-relative walk now only matters for *nested* (non-hoisted) `node_modules` directories, which consequently no longer shadow a same-named module sitting on a search path.

**Relationship to the recent recursion fix**

This is built on top of upstream's recent fix for "default (index.js) module resolution infinite recursion." That fix lives in a different file (the module resolver) and is reached the same way no matter which lookup runs first, so reordering the two lookups does not weaken it. Verified directly: the recursion guard is untouched, and a package directory with no `exports`/`main` field still falls through to its `index.js` exactly as before.

**How to verify**

Rebuild, then run a project headless (`godot --headless --path <project>`) where a script does `require("<dep>")` and both `res://.godot/GodotJS/<dep>.js` and `node_modules/<dep>` exist; confirm the curated bundle loads (no `process is not defined`). Also confirm a directory import of an `exports`-less package still resolves to its `index.js` without hanging.

A changeset is included.
